### PR TITLE
fix: getKoreaTime 수정 및 docker-compose.yml에 TZ 설정 추가 - #112

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,8 @@ services:
     depends_on:
       - redis
       - postgres
+    environment:
+      TZ: 'Asia/Seoul'
 networks:
   shared-network:
     driver: bridge

--- a/src/common/logger.ts
+++ b/src/common/logger.ts
@@ -46,7 +46,8 @@ export const logger = winston.createLogger({
 
 export function getKoreaTime(): Date {
   const now = new Date(); // 현재 시간
-  const utcNow = now.getTime() + now.getTimezoneOffset() * 60 * 1000; // 현재 시간을 UTC로 변환한 밀리세컨드값
+  // 현재 시간을 UTC로 변환한 밀리세컨드값
+  const utcNow = now.getTime(); // + now.getTimezoneOffset() * 60 * 1000; 주석처리된 코드는 docker container의 timezone 또한 Asia/Seoul로 설정되어 있어서 필요없음.
   const koreaTimeDiff = 9 * 60 * 60 * 1000; // 한국 시간과 UTC와의 차이(9시간의 밀리세컨드)
   const koreaNow = new Date(utcNow + koreaTimeDiff); // UTC -> 한국 시간
 


### PR DESCRIPTION
docker container timezone을 Asia/Seoul로 변경함으로 인해 발생한 의도치 않은 버그 해결