### PR TITLE
hotfix: custom repository error 해결 - #115

### DIFF
--- a/src/collections/collections.module.ts
+++ b/src/collections/collections.module.ts
@@ -1,13 +1,31 @@
 import { Module } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import {
+  getDataSourceToken,
+  getRepositoryToken,
+  TypeOrmModule,
+} from '@nestjs/typeorm';
 import { ContentsModule } from 'src/contents/contents.module';
 import { Category } from 'src/contents/entities/category.entity';
+import { customCategoryRepositoryMethods } from 'src/contents/repository/category.repository';
+import { DataSource } from 'typeorm';
 import { CollectionsController } from './collections.controller';
 import { CollectionsService } from './collections.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Category]), ContentsModule],
   controllers: [CollectionsController],
-  providers: [CollectionsService],
+  providers: [
+    CollectionsService,
+    {
+      provide: getRepositoryToken(Category),
+      inject: [getDataSourceToken()],
+      useFactory(dataSource: DataSource) {
+        // Override default repository for Category with a custom one
+        return dataSource
+          .getRepository(Category)
+          .extend(customCategoryRepositoryMethods);
+      },
+    },
+  ],
 })
 export class CollectionsModule {}


### PR DESCRIPTION
collection module에 custom repository를 주입하지 않아 생겼던 오류. -> useFactory를 사용하여 extend된 category repository를 동적으로 생성 후 반환하여 collections module에서도 사용할 수 있도록 함.