### PR TITLE
hotfix: user entity의 name nullable false로 설정 - #118

### DIFF
--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -24,9 +24,9 @@ export enum UserRole {
 @Entity()
 export class User extends CoreEntity {
   @ApiProperty({ example: 'tester', description: 'User Name' })
-  @Column({ nullable: true })
+  @Column()
   @IsString()
-  name?: string;
+  name: string;
 
   @ApiProperty({ example: 'ex@g.com', description: 'User Email' })
   @Column({ unique: true })


### PR DESCRIPTION
name이 빈 user도 저장이 가능했던 탓에
비밀번호 재설정 시 서버 다운되는 현상 발생했었음