### PR TITLE
hotfix: kakao email을 제공하지 않은 경우 처리 - #122

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -222,6 +222,11 @@ export class OauthController {
     description: '로그인 성공 여부와 함께 access, refresh token을 반환한다.',
     type: LoginOutput,
   })
+  @ApiBadRequestResponse({
+    description:
+      '카카오 로그인 요청 시 발생하는 에러를 알려준다.(ex : email 제공에 동의하지 않은 경우)',
+    type: LoginOutput,
+  })
   @ApiUnauthorizedResponse({
     description: '카카오 로그인 실패 여부를 알려준다.',
     type: LoginOutput,

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -468,6 +468,9 @@ export class OauthService {
       }
 
       const email = userInfo.kakao_account.email;
+      if (!email) {
+        throw new BadRequestException('Please Agree to share your email');
+      }
 
       // check user exist with email
       const userInDb = await this.users.findOne({


### PR DESCRIPTION
카카오 로그인 과정에서 카카오 이메일 제공에 동의하지 않은 경우
// check user exist with email
const userInDb = await this.users.findOne({
  where: { email },
  select: { id: true, email: true, password: true },
});
위 작업에서 findOne이 undefined 값과 함께 query를 보내게 되며,
이 경우 항상 DB의 첫번째 레코드를 반환하는 이슈가 있음.

때문에 유저가 이메일 제공에 동의하지 않은 상태로
로그인을 시도하면 다른 유저로 로그인되는 버그가 발생하기 때문에
예외 처리를 추가함.