### PR TITLE
hotfix: 유저 생성 시 name을 unverified로 설정

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -214,6 +214,7 @@ export class AuthService {
     } else {
       newUser = await this.users.save(
         this.users.create({
+          name: 'unverified',
           email,
           password: 'unverified0',
         }),


### PR DESCRIPTION
send verify email api 메서드에서
새 유저 생성 시 name 값을 unverified로 설정하도록 함

현재 DB 스키마가 업데이트되지 않아 name이 비어있는 채로 유저 생성이 가능한 탓에
놓치고 있던 부분을 발견 및 수정함.

여기서 언급한 업데이트된 부분은 user entity의 name column이 non-nullable하게 변경된 부분이다.