### PR TITLE
hotfix: AddCategoryBodyDto의 잘못된 정보 수정 - #141

### DIFF
--- a/src/contents/dtos/category.dto.ts
+++ b/src/contents/dtos/category.dto.ts
@@ -14,7 +14,7 @@ export class AddCategoryBodyDto {
   @ApiProperty({
     description: '부모 카테고리 id',
     example: 1,
-    nullable: true,
+    required: false,
   })
   @IsNumber()
   @IsOptional()


### PR DESCRIPTION
parentId 프로퍼티의 nullable: true를
required: false로 수정