### PR TITLE
hotfix: getOrCreate method 개선 - #143

### DIFF
--- a/src/contents/contents.service.ts
+++ b/src/contents/contents.service.ts
@@ -344,6 +344,8 @@ export class ContentsService {
     const { categoryName: refinedCategoryName, categorySlug } =
       this.categories.generateNameAndSlug(categoryName);
 
+    // if parent id is undefined, set it to null to avoid bug caused by type mismatch
+    if (!parentId) parentId = null;
     // check if category exists in user's categories
     let category: Category = userInDb.categories.find(
       (category) =>


### PR DESCRIPTION
getOrCreate method 동작 과정에서
parentId가 undefined인 경우에 null과의 type mismatch로 인해
기존 카테고리가 존재함에도 새로운 카테고리를 생성하는 버그가 있었음

parentId가 undefined인 경우 null로 초기화하여 해당 버그를 방지함