### PR TITLE
Feature/#147 content save and category policy

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.preferences.importModuleSpecifier": "project-relative"
+}

--- a/Wiki/DB_Migration.md
+++ b/Wiki/DB_Migration.md
@@ -120,3 +120,8 @@ create랑 generate 모두 마이그레이션 파일을 생성하지만 둘 사�
 create는 그냥 빈 파일만을 생성시켜 줄 뿐이지만  
 generate는 db와 entity 사이의 차이점이 있다면 이를 파악하고 sql구문을 작성한다.  
 그러나 컬럼의 길이 또는 타입 변경 시 해당 테이블의 컬럼을 DROP한 후 재생성하는 방식이기 때문에 기존 컬럼에 있던 데이터가 모두 삭제된다.
+
+```bash
+EX)
+npm run migration:generate src/database/migrations/migration_test
+```

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -23,7 +23,7 @@ import {
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
 import { Response } from 'express';
-import { User } from 'src/users/entities/user.entity';
+import { User } from '../users/entities/user.entity';
 import { AuthUser } from './auth-user.decorator';
 import { AuthService, OauthService } from './auth.service';
 import {
@@ -32,7 +32,6 @@ import {
 } from './dtos/create-account.dto';
 import { DeleteAccountOutput } from './dtos/delete-account.dto';
 import { googleUserInfo } from './dtos/google.dto';
-import { LoginWithKakaoDto } from './dtos/kakao.dto';
 import {
   LoginBodyDto,
   LoginOutput,

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -2,7 +2,7 @@ import { CacheModule, Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { User } from 'src/users/entities/user.entity';
+import { User } from '../users/entities/user.entity';
 import { AuthController, OauthController } from './auth.controller';
 import { AuthService, OauthService } from './auth.service';
 import { JwtStrategy } from './jwt/jwt.strategy';

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -2,12 +2,13 @@ import { CACHE_MANAGER } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { CONFIG_OPTIONS } from 'src/common/common.constants';
-import { MailService } from 'src/mail/mail.service';
-import { User } from 'src/users/entities/user.entity';
+import { CONFIG_OPTIONS } from '../common/common.constants';
+import { MailService } from '../mail/mail.service';
+import { User } from '../users/entities/user.entity';
 import { Repository } from 'typeorm';
 import { AuthService } from './auth.service';
 import { customJwtService } from './jwt/jwt.service';
+import { Cache } from 'cache-manager';
 
 const mockRepository = () => ({
   findOne: jest.fn(),

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -9,8 +9,8 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { MailService } from 'src/mail/mail.service';
-import { User } from 'src/users/entities/user.entity';
+import { MailService } from '../mail/mail.service';
+import { User } from '../users/entities/user.entity';
 import { Repository } from 'typeorm';
 import {
   refreshTokenExpirationInCache,

--- a/src/auth/dtos/create-account.dto.ts
+++ b/src/auth/dtos/create-account.dto.ts
@@ -1,5 +1,5 @@
 import { PickType } from '@nestjs/swagger';
-import { CoreOutput } from 'src/common/dtos/output.dto';
+import { CoreOutput } from '../../common/dtos/output.dto';
 import { User } from '../../users/entities/user.entity';
 
 export class CreateAccountBodyDto extends PickType(User, [

--- a/src/auth/dtos/delete-account.dto.ts
+++ b/src/auth/dtos/delete-account.dto.ts
@@ -1,3 +1,3 @@
-import { CoreOutput } from 'src/common/dtos/output.dto';
+import { CoreOutput } from '../../common/dtos/output.dto';
 
 export class DeleteAccountOutput extends CoreOutput {}

--- a/src/auth/dtos/kakao.dto.ts
+++ b/src/auth/dtos/kakao.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty, PickType } from '@nestjs/swagger';
 import { IsOptional, IsString } from 'class-validator';
-import { CoreOutput } from 'src/common/dtos/output.dto';
-import { User } from 'src/users/entities/user.entity';
+import { CoreOutput } from '../../common/dtos/output.dto';
+import { User } from '../../users/entities/user.entity';
 
 export class LoginWithKakaoDto {
   @ApiProperty({ description: 'kakao authorize code' })

--- a/src/auth/dtos/login.dto.ts
+++ b/src/auth/dtos/login.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty, PickType } from '@nestjs/swagger';
 import { IsBoolean, IsOptional, IsString } from 'class-validator';
-import { CoreOutput } from 'src/common/dtos/output.dto';
+import { CoreOutput } from '../../common/dtos/output.dto';
 import { User } from '../../users/entities/user.entity';
 
 export class LoginBodyDto extends PickType(User, ['email', 'password']) {

--- a/src/auth/dtos/send-password-reset-email.dto.ts
+++ b/src/auth/dtos/send-password-reset-email.dto.ts
@@ -1,3 +1,3 @@
-import { CoreOutput } from 'src/common/dtos/output.dto';
+import { CoreOutput } from '../../common/dtos/output.dto';
 
 export class sendPasswordResetEmailOutput extends CoreOutput {}

--- a/src/auth/dtos/token.dto.ts
+++ b/src/auth/dtos/token.dto.ts
@@ -1,6 +1,6 @@
-import { ApiProperty, PickType } from '@nestjs/swagger';
+import { ApiProperty } from '@nestjs/swagger';
 import { IsOptional, IsString } from 'class-validator';
-import { CoreOutput } from 'src/common/dtos/output.dto';
+import { CoreOutput } from '../../common/dtos/output.dto';
 
 export class RefreshTokenDto {
   @ApiProperty({ description: 'refresh token', required: true })

--- a/src/auth/dtos/validate-user.dto.ts
+++ b/src/auth/dtos/validate-user.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty, PickType } from '@nestjs/swagger';
-import { CoreOutput } from 'src/common/dtos/output.dto';
-import { User } from 'src/users/entities/user.entity';
+import { CoreOutput } from '../../common/dtos/output.dto';
+import { User } from '../../users/entities/user.entity';
 
 export class ValidateUserDto extends PickType(User, ['email', 'password']) {}
 

--- a/src/auth/dtos/verify-email.dto.ts
+++ b/src/auth/dtos/verify-email.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsOptional, IsString } from 'class-validator';
-import { CoreOutput } from 'src/common/dtos/output.dto';
+import { CoreOutput } from '../../common/dtos/output.dto';
 
 export class VerifyEmailOutput extends CoreOutput {
   @ApiProperty({ description: '인증된 이메일', required: false })

--- a/src/auth/jwt/jwt.strategy.ts
+++ b/src/auth/jwt/jwt.strategy.ts
@@ -2,7 +2,7 @@ import { ExtractJwt, Strategy } from 'passport-jwt';
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { Payload } from './jwt.payload';
-import { User } from 'src/users/entities/user.entity';
+import { User } from '../../users/entities/user.entity';
 import { Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
 

--- a/src/auth/role.decorator.ts
+++ b/src/auth/role.decorator.ts
@@ -1,5 +1,5 @@
 import { SetMetadata } from '@nestjs/common';
-import { UserRole } from 'src/users/entities/user.entity';
+import { UserRole } from '../users/entities/user.entity';
 
 export type AllowedRoles = keyof typeof UserRole | 'Any';
 

--- a/src/auth/role.guard.ts
+++ b/src/auth/role.guard.ts
@@ -1,7 +1,7 @@
 import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { AllowedRoles } from './role.decorator';
-import { User } from 'src/users/entities/user.entity';
+import { User } from '../users/entities/user.entity';
 
 @Injectable()
 export class RoleGuard implements CanActivate {

--- a/src/contents/contents.controller.ts
+++ b/src/contents/contents.controller.ts
@@ -20,11 +20,11 @@ import {
   ApiOperation,
   ApiTags,
 } from '@nestjs/swagger';
-import { AuthUser } from 'src/auth/auth-user.decorator';
-import { JwtAuthGuard } from 'src/auth/jwt/jwt.guard';
-import { TransactionInterceptor } from 'src/common/interceptors/transaction.interceptor';
-import { TransactionManager } from 'src/common/transaction.decorator';
-import { User } from 'src/users/entities/user.entity';
+import { AuthUser } from '../auth/auth-user.decorator';
+import { JwtAuthGuard } from '../auth/jwt/jwt.guard';
+import { TransactionInterceptor } from '../common/interceptors/transaction.interceptor';
+import { TransactionManager } from '../common/transaction.decorator';
+import { User } from '../users/entities/user.entity';
 import { EntityManager } from 'typeorm';
 import { CategoryService, ContentsService } from './contents.service';
 import {
@@ -46,7 +46,10 @@ import {
   UpdateContentBodyDto,
   UpdateContentOutput,
 } from './dtos/content.dto';
-import { LoadPersonalCategoriesOutput } from './dtos/load-personal-categories.dto';
+import {
+  LoadPersonalCategoriesOutput,
+  LoadRecentCategoriesOutput,
+} from './dtos/load-personal-categories.dto';
 
 @Controller('contents')
 @ApiTags('Contents')
@@ -365,5 +368,22 @@ export class CategoryController {
     @AuthUser() user: User,
   ): Promise<LoadPersonalCategoriesOutput> {
     return await this.categoryService.loadPersonalCategories(user);
+  }
+
+  @ApiOperation({
+    summary: '최근 저장한 카테고리 조회',
+    description: '최근 저장한 카테고리를 3개까지 조회하는 메서드',
+  })
+  @ApiOkResponse({
+    description: '최근 저장한 카테고리를 최대 3개까지 반환한다.',
+    type: LoadRecentCategoriesOutput,
+  })
+  @ApiBearerAuth('Authorization')
+  @UseGuards(JwtAuthGuard)
+  @Get('load-recent-categories')
+  async loadRecentCategories(
+    @AuthUser() user: User,
+  ): Promise<LoadRecentCategoriesOutput> {
+    return await this.categoryService.loadRecentCategories(user);
   }
 }

--- a/src/contents/contents.controller.ts
+++ b/src/contents/contents.controller.ts
@@ -46,6 +46,7 @@ import {
   UpdateContentBodyDto,
   UpdateContentOutput,
 } from './dtos/content.dto';
+import { LoadPersonalCategoriesOutput } from './dtos/load-personal-categories.dto';
 
 @Controller('contents')
 @ApiTags('Contents')
@@ -347,5 +348,22 @@ export class CategoryController {
       categoryId,
       queryRunnerManager,
     );
+  }
+
+  @ApiOperation({
+    summary: '자신의 카테고리 목록 조회',
+    description: '자신의 카테고리 목록을 조회하는 메서드',
+  })
+  @ApiOkResponse({
+    description: '카테고리 목록을 반환한다.',
+    type: LoadPersonalCategoriesOutput,
+  })
+  @ApiBearerAuth('Authorization')
+  @UseGuards(JwtAuthGuard)
+  @Get('load-categories')
+  async loadPersonalCategories(
+    @AuthUser() user: User,
+  ): Promise<LoadPersonalCategoriesOutput> {
+    return await this.categoryService.loadPersonalCategories(user);
   }
 }

--- a/src/contents/contents.module.ts
+++ b/src/contents/contents.module.ts
@@ -15,17 +15,9 @@ import { CategoryService, ContentsService } from './contents.service';
 import { Category } from './entities/category.entity';
 import { Content } from './entities/content.entity';
 import { customCategoryRepositoryMethods } from './repository/category.repository';
-import * as redisStore from 'cache-manager-redis-store';
 
 @Module({
-  imports: [
-    TypeOrmModule.forFeature([User, Content, Category]),
-    CacheModule.register({
-      store: redisStore,
-      host: process.env.REDIS_HOST,
-      port: process.env.REDIS_PORT,
-    }),
-  ],
+  imports: [TypeOrmModule.forFeature([User, Content, Category])],
   controllers: [ContentsController, CategoryController, TestController],
   providers: [
     ContentsService,

--- a/src/contents/contents.module.ts
+++ b/src/contents/contents.module.ts
@@ -4,7 +4,7 @@ import {
   getRepositoryToken,
   TypeOrmModule,
 } from '@nestjs/typeorm';
-import { User } from 'src/users/entities/user.entity';
+import { User } from '../users/entities/user.entity';
 import { DataSource } from 'typeorm';
 import {
   CategoryController,

--- a/src/contents/contents.module.ts
+++ b/src/contents/contents.module.ts
@@ -17,8 +17,8 @@ import { Content } from './entities/content.entity';
 import { customCategoryRepositoryMethods } from './repository/category.repository';
 import * as redisStore from 'cache-manager-redis-store';
 
-// 카테고리에 저장된 콘텐츠 카운트 캐시에 2달간 저장을 위한 시간 값
-export const categoryCountExpirationInCache = 60 * 60 * 24 * 60;
+// 카테고리에 저장된 콘텐츠 카운트를 캐시에 2일간 저장하기 위한 시간 값
+export const categoryCountExpirationInCache = 60 * 60 * 24 * 2;
 
 @Module({
   imports: [

--- a/src/contents/contents.module.ts
+++ b/src/contents/contents.module.ts
@@ -17,9 +17,6 @@ import { Content } from './entities/content.entity';
 import { customCategoryRepositoryMethods } from './repository/category.repository';
 import * as redisStore from 'cache-manager-redis-store';
 
-// 카테고리에 저장된 콘텐츠 카운트를 캐시에 2일간 저장하기 위한 시간 값
-export const categoryCountExpirationInCache = 60 * 60 * 24 * 2;
-
 @Module({
   imports: [
     TypeOrmModule.forFeature([User, Content, Category]),

--- a/src/contents/contents.module.ts
+++ b/src/contents/contents.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { CacheModule, Module } from '@nestjs/common';
 import {
   getDataSourceToken,
   getRepositoryToken,
@@ -15,9 +15,20 @@ import { CategoryService, ContentsService } from './contents.service';
 import { Category } from './entities/category.entity';
 import { Content } from './entities/content.entity';
 import { customCategoryRepositoryMethods } from './repository/category.repository';
+import * as redisStore from 'cache-manager-redis-store';
+
+// 카테고리에 저장된 콘텐츠 카운트 캐시에 2달간 저장을 위한 시간 값
+export const categoryCountExpirationInCache = 60 * 60 * 24 * 60;
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User, Content, Category])],
+  imports: [
+    TypeOrmModule.forFeature([User, Content, Category]),
+    CacheModule.register({
+      store: redisStore,
+      host: process.env.REDIS_HOST,
+      port: process.env.REDIS_PORT,
+    }),
+  ],
   controllers: [ContentsController, CategoryController, TestController],
   providers: [
     ContentsService,

--- a/src/contents/contents.service.spec.ts
+++ b/src/contents/contents.service.spec.ts
@@ -367,13 +367,14 @@ describe('CategoryService', () => {
 
       const { recentCategories } = await service.loadRecentCategories(fakeUser);
 
+      console.log(recentCategories);
       expect(recentCategories).toHaveLength(3);
       expect(recentCategories[0].id).toBe(1);
       expect(recentCategories[1].id).toBe(3);
       expect(recentCategories[2].id).toBe(5);
     });
 
-    it('저장한 콘텐츠가 3개인 경우', async () => {
+    it('전체 저장한 콘텐츠가 하나의 카테고리 안에 3개인 경우', async () => {
       usersRepository.findOne.mockReturnValue(fakeUser);
 
       categoryRepository.findOne.mockImplementation(({ where: { id } }) => {

--- a/src/contents/contents.service.spec.ts
+++ b/src/contents/contents.service.spec.ts
@@ -13,6 +13,7 @@ import {
   CategoryRepository,
   customCategoryRepositoryMethods,
 } from './repository/category.repository';
+import { RecentCategoryList } from './dtos/category.dto';
 
 const mockRepository = () => ({
   // make as a function type that returns Object.
@@ -211,8 +212,8 @@ describe('CategoryService', () => {
         id: 1,
         createdAt: undefined,
         updatedAt: undefined,
-        name: 'test1',
-        slug: 'test1',
+        name: 'Dev',
+        slug: 'Dev',
         userId: 1,
         collections: [],
         contents: [],
@@ -222,8 +223,30 @@ describe('CategoryService', () => {
         id: 2,
         createdAt: undefined,
         updatedAt: undefined,
-        name: 'test2',
-        slug: 'test2',
+        name: '쇼핑리스트',
+        slug: '쇼핑리스트',
+        userId: 1,
+        collections: [],
+        contents: [],
+        user: undefined,
+      },
+      {
+        id: 3,
+        createdAt: undefined,
+        updatedAt: undefined,
+        name: '운동',
+        slug: '운동',
+        userId: 1,
+        collections: [],
+        contents: [],
+        user: undefined,
+      },
+      {
+        id: 4,
+        createdAt: undefined,
+        updatedAt: undefined,
+        name: '여행',
+        slug: '여행',
         userId: 1,
         collections: [],
         contents: [],
@@ -233,8 +256,8 @@ describe('CategoryService', () => {
         id: 5,
         createdAt: undefined,
         updatedAt: undefined,
-        name: 'test5',
-        slug: 'test5',
+        name: '꿀팁',
+        slug: '꿀팁',
         userId: 1,
         collections: [],
         contents: [],
@@ -244,8 +267,8 @@ describe('CategoryService', () => {
         id: 6,
         createdAt: undefined,
         updatedAt: undefined,
-        name: 'test6',
-        slug: 'test6',
+        name: '데이터분석',
+        slug: '데이터분석',
         userId: 1,
         collections: [],
         contents: [],
@@ -255,40 +278,183 @@ describe('CategoryService', () => {
 
     fakeUser.categories = [...fakeCategories];
 
-    it('캐시 내에 2일 내 기록된 카테고리가 두 종류 뿐이라면 recentCategories는 2개여야만 한다.', async () => {
+    it('최초 호출에서 n번자리가 모두 확정된 경우', async () => {
       usersRepository.findOne.mockReturnValue(fakeUser);
 
       categoryRepository.findOne.mockImplementation(({ where: { id } }) => {
         return fakeCategories.find((category) => category.id === id);
       });
 
-      cacheManager.get.mockReturnValue([
-        { categoryId: 1, savedAt: new Date() },
-        { categoryId: 2, savedAt: new Date() },
-      ]);
+      // 콘텐츠 저장 기록
+      /**
+       * Dev : categoryId 1
+       * 쇼핑리스트 : categoryId 2
+       * 꿀팁 : categoryId 5
+       * 데이터분석 : categoryId 6
+       *
+       * 2023.01.15 07:30:00 Dev에 저장
+       * 2023.01.15 07:25:00 쇼핑리스트에 저장
+       * 2023.01.15 07:15:00 Dev에 저장
+       * 2023.01.10 21:00:00 꿀팁에 저장
+       * 2023.01.10 20:50:00 Dev에 저장
+       * 2022.12.29 09:00:00 데이터분석에 저장
+       * 2022.06.20 20:45:00 쇼핑리스트에 저장
+       * 2022.06.20 20:50:00 Dev에 저장
+       * 2022.06.20 20:10:00 Dev에 저장
+       * 2022.06.17 01:30:00 Dev에 저장
+       */
+      const recentCategoryList: RecentCategoryList[] = [
+        { categoryId: 1, savedAt: new Date('2023-01-15 07:30:00').getTime() },
+        { categoryId: 2, savedAt: new Date('2023-01-15 07:25:00').getTime() },
+        { categoryId: 1, savedAt: new Date('2023-01-15 07:15:00').getTime() },
+        { categoryId: 5, savedAt: new Date('2023-01-10 21:00:00').getTime() },
+        { categoryId: 1, savedAt: new Date('2023-01-10 20:50:00').getTime() },
+        { categoryId: 6, savedAt: new Date('2022-12-29 09:00:00').getTime() },
+        { categoryId: 2, savedAt: new Date('2022-06-20 20:45:00').getTime() },
+        { categoryId: 1, savedAt: new Date('2022-06-20 20:50:00').getTime() },
+        { categoryId: 1, savedAt: new Date('2022-06-20 20:10:00').getTime() },
+        { categoryId: 1, savedAt: new Date('2022-06-17 01:30:00').getTime() },
+      ];
+
+      service.loadLogs = jest.fn().mockReturnValue(recentCategoryList);
 
       const { recentCategories } = await service.loadRecentCategories(fakeUser);
 
-      expect(recentCategories).toHaveLength(2);
+      expect(recentCategories).toHaveLength(3);
+      expect(recentCategories[0].id).toBe(1);
+      expect(recentCategories[1].id).toBe(2);
+      expect(recentCategories[2].id).toBe(5);
     });
 
-    it('캐시 내에 2일이 지난 데이터가 있다면 취급하지 않아야 한다.', async () => {
+    it('최초 호출에서 n번자리가 모두 확정되지 않은 경우', async () => {
       usersRepository.findOne.mockReturnValue(fakeUser);
 
       categoryRepository.findOne.mockImplementation(({ where: { id } }) => {
         return fakeCategories.find((category) => category.id === id);
       });
 
-      const time: Date = new Date();
-      cacheManager.get.mockReturnValue([
-        { categoryId: 1, savedAt: new Date().setDate(time.getDate() - 2) }, // 2일 전 기록
-        { categoryId: 2, savedAt: new Date().setDate(time.getDate() - 1) }, // 하루 전 기록
-        { categoryId: 5, savedAt: new Date().setDate(time.getDate() - 3) }, // 3일 전 기록
-      ]);
+      // 콘텐츠 저장 기록
+      /**
+       * Dev : categoryId 1
+       * 쇼핑리스트 : categoryId 2
+       * 운동 : categoryId 3
+       * 여행 : categoryId 4
+       * 꿀팁 : categoryId 5
+       * 데이터분석 : categoryId 6
+       *
+       * 2023.01.15 07:30:00 Dev에 저장
+       * 2023.01.15 07:25:00 Dev에 저장
+       * 2023.01.15 07:15:00 Dev에 저장
+       * 2023.01.10 21:00:00 Dev에 저장
+       * 2023.01.10 20:50:00 Dev에 저장
+       * 2022.12.29 09:00:00 Dev에 저장
+       * 2022.06.20 20:45:00 Dev에 저장
+       * 2022.06.20 20:50:00 Dev에 저장
+       * 2022.06.20 20:10:00 Dev에 저장
+       * 2022.06.17 01:30:00 Dev에 저장
+       *
+       * 2022.06.16 07:30:00 Dev에 저장
+       * 2022.05.10 08:25:00 운동에 저장
+       * 2022.05.03 14:00:00 꿀팁에 저장
+       * 2022.05.02 20:30:00 운동에 저장
+       * 2022.05.02 20:30:00 운동에 저장
+       * 2022.04.29 09:00:00 쇼핑리스트에 저장
+       * 2022.04.20 23:55:00 여행에 저장
+       * 2022.04.20 23:45:00 꿀팁에 저장
+       * 2022.04.20 23:00:00 꿀팁에 저장
+       */
+      const recentCategoryList: RecentCategoryList[] = [
+        { categoryId: 1, savedAt: new Date('2023-01-15 07:30:00').getTime() },
+        { categoryId: 1, savedAt: new Date('2023-01-15 07:25:00').getTime() },
+        { categoryId: 1, savedAt: new Date('2023-01-15 07:15:00').getTime() },
+        { categoryId: 1, savedAt: new Date('2023-01-10 21:00:00').getTime() },
+        { categoryId: 1, savedAt: new Date('2023-01-10 20:50:00').getTime() },
+        { categoryId: 1, savedAt: new Date('2022-12-29 09:00:00').getTime() },
+        { categoryId: 1, savedAt: new Date('2022-06-20 20:45:00').getTime() },
+        { categoryId: 1, savedAt: new Date('2022-06-20 20:50:00').getTime() },
+        { categoryId: 1, savedAt: new Date('2022-06-20 20:10:00').getTime() },
+        { categoryId: 1, savedAt: new Date('2022-06-17 01:30:00').getTime() },
+        { categoryId: 1, savedAt: new Date('2022-06-16 07:30:00').getTime() },
+        { categoryId: 3, savedAt: new Date('2022-05-10 08:25:00').getTime() },
+        { categoryId: 5, savedAt: new Date('2022-05-03 14:00:00').getTime() },
+        { categoryId: 3, savedAt: new Date('2022-05-02 20:30:00').getTime() },
+        { categoryId: 3, savedAt: new Date('2022-05-02 20:30:00').getTime() },
+        { categoryId: 2, savedAt: new Date('2022-04-29 09:00:00').getTime() },
+        { categoryId: 4, savedAt: new Date('2022-04-20 23:55:00').getTime() },
+        { categoryId: 5, savedAt: new Date('2022-04-20 23:45:00').getTime() },
+        { categoryId: 5, savedAt: new Date('2022-04-20 23:00:00').getTime() },
+      ];
+
+      service.loadLogs = jest.fn().mockReturnValue(recentCategoryList);
+
+      const { recentCategories } = await service.loadRecentCategories(fakeUser);
+
+      expect(recentCategories).toHaveLength(3);
+      expect(recentCategories[0].id).toBe(1);
+      expect(recentCategories[1].id).toBe(3);
+      expect(recentCategories[2].id).toBe(5);
+    });
+
+    it('저장한 콘텐츠가 3개인 경우', async () => {
+      usersRepository.findOne.mockReturnValue(fakeUser);
+
+      categoryRepository.findOne.mockImplementation(({ where: { id } }) => {
+        return fakeCategories.find((category) => category.id === id);
+      });
+
+      // 콘텐츠 저장 기록
+      /**
+       * Dev : categoryId 1
+       *
+       * 2023.01.15 07:30:00 Dev에 저장
+       * 2023.01.15 07:25:00 Dev에 저장
+       * 2023.01.15 07:15:00 Dev에 저장
+       */
+      const recentCategoryList: RecentCategoryList[] = [
+        { categoryId: 1, savedAt: new Date('2023-01-15 07:30:00').getTime() },
+        { categoryId: 1, savedAt: new Date('2023-01-15 07:25:00').getTime() },
+        { categoryId: 1, savedAt: new Date('2023-01-15 07:15:00').getTime() },
+      ];
+
+      service.loadLogs = jest.fn().mockReturnValue(recentCategoryList);
 
       const { recentCategories } = await service.loadRecentCategories(fakeUser);
 
       expect(recentCategories).toHaveLength(1);
+      expect(recentCategories[0].id).toBe(1);
+    });
+
+    it('저장 횟수 공동 1번이 있는 경우', async () => {
+      usersRepository.findOne.mockReturnValue(fakeUser);
+
+      categoryRepository.findOne.mockImplementation(({ where: { id } }) => {
+        return fakeCategories.find((category) => category.id === id);
+      });
+
+      // 콘텐츠 저장 기록
+      /**
+       * Dev : categoryId 1
+       * 쇼핑리스트 : categoryId 2
+       * 운동 : categoryId 3
+       *
+       * 2023.01.15 07:30:00 Dev에 저장
+       * 2023.01.15 07:25:00 운동에 저장
+       * 2023.01.15 07:15:00 쇼핑리스트에 저장
+       */
+      const recentCategoryList: RecentCategoryList[] = [
+        { categoryId: 1, savedAt: new Date('2023-01-15 07:30:00').getTime() },
+        { categoryId: 3, savedAt: new Date('2023-01-15 07:25:00').getTime() },
+        { categoryId: 2, savedAt: new Date('2023-01-15 07:15:00').getTime() },
+      ];
+
+      service.loadLogs = jest.fn().mockReturnValue(recentCategoryList);
+
+      const { recentCategories } = await service.loadRecentCategories(fakeUser);
+
+      expect(recentCategories).toHaveLength(3);
+      expect(recentCategories[0].id).toBe(1);
+      expect(recentCategories[1].id).toBe(3);
+      expect(recentCategories[2].id).toBe(2);
     });
   });
 });

--- a/src/contents/contents.service.spec.ts
+++ b/src/contents/contents.service.spec.ts
@@ -1,13 +1,11 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { getDataSourceToken, getRepositoryToken } from '@nestjs/typeorm';
+import { getRepositoryToken } from '@nestjs/typeorm';
 import { CONFIG_OPTIONS } from '../common/common.constants';
 import { SummaryService } from '../summary/summary.service';
 import { User, UserRole } from '../users/entities/user.entity';
 import { DataSource, Repository } from 'typeorm';
 import { CategoryService, ContentsService } from './contents.service';
 import { Content } from './entities/content.entity';
-import { Cache } from 'cache-manager';
-import { CACHE_MANAGER } from '@nestjs/common';
 import { Category } from './entities/category.entity';
 import {
   CategoryRepository,
@@ -49,7 +47,6 @@ describe('ContentsService', () => {
   let usersRepository: MockRepository<User>;
   let summarizeService: SummaryService;
   let categoryRepository: CategoryRepository;
-  let cacheManager: Cache;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -67,14 +64,6 @@ describe('ContentsService', () => {
         {
           provide: getRepositoryToken(Category),
           useValue: mockCategoryRepository(),
-        },
-        {
-          provide: CACHE_MANAGER,
-          useValue: {
-            get: jest.fn(),
-            set: jest.fn(),
-            del: jest.fn(),
-          },
         },
         {
           provide: DataSource,
@@ -95,7 +84,6 @@ describe('ContentsService', () => {
     usersRepository = module.get(getRepositoryToken(User));
     summarizeService = module.get<SummaryService>(SummaryService);
     categoryRepository = module.get(getRepositoryToken(Category));
-    cacheManager = module.get<Cache>(CACHE_MANAGER);
   });
 
   it('should be defined', () => {
@@ -154,7 +142,6 @@ describe('CategoryService', () => {
   let service: CategoryService;
   let categoryRepository: MockRepository<CategoryRepository>;
   let usersRepository: MockRepository<User>;
-  let cacheManager: Cache;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -169,14 +156,6 @@ describe('CategoryService', () => {
           useValue: mockRepository(),
         },
         {
-          provide: CACHE_MANAGER,
-          useValue: {
-            get: jest.fn(),
-            set: jest.fn(),
-            del: jest.fn(),
-          },
-        },
-        {
           provide: DataSource,
           useClass: class MockDataSource {},
         },
@@ -186,7 +165,6 @@ describe('CategoryService', () => {
     service = module.get<CategoryService>(CategoryService);
     categoryRepository = module.get(getRepositoryToken(Category));
     usersRepository = module.get(getRepositoryToken(User));
-    cacheManager = module.get(CACHE_MANAGER);
   });
 
   it('should be defined', () => {

--- a/src/contents/contents.service.spec.ts
+++ b/src/contents/contents.service.spec.ts
@@ -367,7 +367,6 @@ describe('CategoryService', () => {
 
       const { recentCategories } = await service.loadRecentCategories(fakeUser);
 
-      console.log(recentCategories);
       expect(recentCategories).toHaveLength(3);
       expect(recentCategories[0].id).toBe(1);
       expect(recentCategories[1].id).toBe(3);

--- a/src/contents/contents.service.spec.ts
+++ b/src/contents/contents.service.spec.ts
@@ -214,7 +214,6 @@ describe('CategoryService', () => {
         name: 'test1',
         slug: 'test1',
         userId: 1,
-        saves: 3,
         collections: [],
         contents: [],
         user: fakeUser,
@@ -226,7 +225,6 @@ describe('CategoryService', () => {
         name: 'test2',
         slug: 'test2',
         userId: 1,
-        saves: 2,
         collections: [],
         contents: [],
         user: fakeUser,
@@ -247,13 +245,34 @@ describe('CategoryService', () => {
         updatedAt: undefined,
         categories: [
           {
+            id: 1,
+            createdAt: undefined,
+            updatedAt: undefined,
+            name: 'test1',
+            slug: 'test1',
+            userId: 1,
+            collections: [],
+            contents: [],
+            user: fakeUser,
+          },
+          {
+            id: 2,
+            createdAt: undefined,
+            updatedAt: undefined,
+            name: 'test2',
+            slug: 'test2',
+            userId: 1,
+            collections: [],
+            contents: [],
+            user: fakeUser,
+          },
+          {
             id: 5,
             createdAt: undefined,
             updatedAt: undefined,
             name: 'test5',
             slug: 'test5',
             userId: 1,
-            saves: 7,
           },
           {
             id: 6,
@@ -262,7 +281,6 @@ describe('CategoryService', () => {
             name: 'test6',
             slug: 'test6',
             userId: 1,
-            saves: 17,
           },
         ],
       });
@@ -272,13 +290,13 @@ describe('CategoryService', () => {
       });
 
       cacheManager.get.mockReturnValue([
-        { categoryId: 1, categorySaves: 3 },
-        { categoryId: 2, categorySaves: 2 },
+        { categoryId: 1, savedAt: new Date() },
+        { categoryId: 2, savedAt: new Date() },
       ]);
 
       const { recentCategories } = await service.loadRecentCategories(fakeUser);
 
-      expect(recentCategories).toHaveLength(3);
+      expect(recentCategories).toHaveLength(2);
     });
   });
 });

--- a/src/contents/contents.service.ts
+++ b/src/contents/contents.service.ts
@@ -796,23 +796,16 @@ export class CategoryService {
         saveCount: number;
       }
       // 캐시 내의 카테고리 리스트를 가져온다.
-      const recentCategoryList: RecentCategoryList[] =
+      let recentCategoryList: RecentCategoryList[] =
         await this.cacheManager.get(user.id);
 
       // 2일 내의 데이터만 남긴 후 캐시 저장소에 반영한다.
       const time: Date = new Date();
       time.setDate(time.getDate() - 2);
       if (recentCategoryList) {
-        recentCategoryList.filter((category) => {
-          console.log(
-            time,
-            ' ',
-            category.savedAt,
-            ' ',
-            time < category.savedAt,
-          );
-          return time < category.savedAt;
-        });
+        recentCategoryList = recentCategoryList.filter(
+          (category) => time < category.savedAt,
+        );
       }
       this.cacheManager.set(user.id, recentCategoryList, {
         ttl: categoryCountExpirationInCache,

--- a/src/contents/contents.service.ts
+++ b/src/contents/contents.service.ts
@@ -32,9 +32,9 @@ import {
 import {
   LoadPersonalCategoriesOutput,
   LoadRecentCategoriesOutput,
-} from 'src/contents/dtos/load-personal-categories.dto';
-import { SummaryService } from 'src/summary/summary.service';
-import { User } from 'src/users/entities/user.entity';
+} from './dtos/load-personal-categories.dto';
+import { SummaryService } from '../summary/summary.service';
+import { User } from '../users/entities/user.entity';
 import { Category } from './entities/category.entity';
 import { Content } from './entities/content.entity';
 import { CategoryRepository } from './repository/category.repository';
@@ -821,15 +821,14 @@ export class CategoryService {
 
       // 카테고리별로 저장된 콘텐츠 수를 세어서 오름차순으로 정렬
       const recentCategories: Category[] = [];
-
       // Cache
       let categoryCount: CategoryCount[] = await this.cacheManager.get(user.id);
       if (categoryCount) {
         categoryCount = categoryCount.sort(
-          (a, b) => a.categorySaves - b.categorySaves,
+          (a, b) => b.categorySaves - a.categorySaves,
         );
         for (let i = 0; i < 3; i++) {
-          if (categoryCount.length > i) {
+          if (categoryCount.length === i) {
             break;
           }
           const current_category = await this.categories.findOne({
@@ -848,8 +847,8 @@ export class CategoryService {
       }
 
       // recentCategories가 3개보다 크다면 recentCategories를 잘라줌
-      if (recentCategories.length >= 3) {
-        recentCategories.splice(0, 3);
+      if (recentCategories.length > 3) {
+        recentCategories.splice(3);
       }
 
       return {

--- a/src/contents/contents.service.ts
+++ b/src/contents/contents.service.ts
@@ -206,12 +206,13 @@ export class ContentsService {
       }
 
       const category = await this.getOrCreateCategory(
-        // link,
         categoryName,
         parentId,
         userInDb,
         queryRunnerManager,
       );
+
+      this.checkContentDuplicateAndPlusCategoryCount(link, category, userInDb);
 
       queryRunnerManager.save(Content, [
         { id: content.id, ...newContentObj, ...(category && { category }) },

--- a/src/contents/contents.service.ts
+++ b/src/contents/contents.service.ts
@@ -565,7 +565,7 @@ export class ContentsService {
       }
 
       // 문서 요약을 위한 본문 크롤링
-      let document: string = await this.summaryService.getDocument(
+      const document: string = await this.summaryService.getDocument(
         content.link,
       );
 

--- a/src/contents/contents.service.ts
+++ b/src/contents/contents.service.ts
@@ -815,8 +815,6 @@ export class CategoryService {
         await this.cacheManager.get(user.id);
 
       // 2일 내의 데이터만 남긴 후 캐시 저장소에 반영한다.
-      const recentCategoryListWithSaveCount: RecentCategoryListWithSaveCount[] =
-        [];
       const time: Date = new Date();
       time.setDate(time.getDate() - 2);
       if (recentCategoryList) {

--- a/src/contents/contents.service.ts
+++ b/src/contents/contents.service.ts
@@ -481,7 +481,6 @@ export class ContentsService {
       .get(link)
       .then((res) => {
         if (res.status !== 200) {
-          console.log(res.status);
           throw new BadRequestException('잘못된 링크입니다.');
         } else {
           const data = res.data;
@@ -504,7 +503,6 @@ export class ContentsService {
         }
       })
       .catch((e) => {
-        console.log(e.message);
         // Control unreachable link
         // if(e.message === 'Request failed with status code 403') {
         // 403 에러가 발생하는 링크는 크롤링이 불가능한 링크이다.
@@ -784,17 +782,33 @@ export class CategoryService {
       const recentCategories: Category[] = [];
 
       // 3번째 카테고리까지 선정되거나, 더 이상 로그가 없을 때까지 매번 10개의 로그씩 확인한다.
-      for (let i = 0; i < recentCategoryList.length / 10; i++) {
+      let remainLogCount = recentCategoryList.length,
+        i = 0;
+      while (remainLogCount > 0) {
         // 3개의 카테고리가 선정되었으면 루프를 종료한다.
         if (recentCategories.length >= 3) {
           break;
         }
 
         // 10개의 로그를 확인한다.
+        i += 10;
         recentCategoriesWithSaveCount = this.makeCategoryListWithSaveCount(
           recentCategoryList,
           recentCategoriesWithSaveCount,
-          i + 10,
+          i,
+        );
+        // 10개의 로그를 확인했으므로 남은 로그 수를 10개 감소시킨다.
+        remainLogCount -= 10;
+
+        /*
+         * 10개의 로그를 확인하고, 만약 이전 호출에서 선정된 카테고리가 이번 호출에서도 선정되는 것을 방지하기위해
+         * 이전 호출에서 선정된 카테고리를 제외한 카테고리 리스트를 만든다.
+         */
+        recentCategoriesWithSaveCount = recentCategoriesWithSaveCount.filter(
+          (category) =>
+            !recentCategories.find(
+              (recentCategory) => recentCategory.id === category.categoryId,
+            ),
         );
 
         // 최근 저장 순
@@ -806,7 +820,6 @@ export class CategoryService {
           recentCategoriesWithSaveCount.sort(
             (a, b) => b.saveCount - a.saveCount,
           );
-
         /*
          * 2번째 카테고리까지 선정 기준
          * 1. 저장 횟수 순

--- a/src/contents/contents.service.ts
+++ b/src/contents/contents.service.ts
@@ -103,8 +103,6 @@ export class ContentsService {
         ...(favorite && { favorite }),
       });
       await queryRunnerManager.save(newContent);
-      userInDb.contents.push(newContent);
-      await queryRunnerManager.save(userInDb);
 
       return;
     } catch (e) {
@@ -148,11 +146,10 @@ export class ContentsService {
             siteName,
             coverImg,
             description,
+            user: userInDb,
           });
           await queryRunnerManager.save(newContent);
-          userInDb.contents.push(newContent);
         }
-        await queryRunnerManager.save(userInDb);
       }
 
       return;
@@ -404,7 +401,9 @@ export class ContentsService {
       category,
     );
 
-    // 카테고리의 중복을 체크하고, 중복이 없다면 최상위 카테고리의 count를 증가시킴
+    /*
+     * 카테고리의 중복을 체크하고, 중복이 없다면 최상위 카테고리의 count를 증가시킴
+     */
 
     // flat categoryFamily with children
     categoryFamily.reduce((acc, cur) => {

--- a/src/contents/contents.service.ts
+++ b/src/contents/contents.service.ts
@@ -461,14 +461,13 @@ export class ContentsService {
     }
 
     /*
-     * 최상위 카테고리의 count를 증가시킨 후, 해당 카테고리를 저장함
+     * 최상위 카테고리의 count를 증가시킨 후, 해당 카테고리를 저장 기록을 추가함
      */
 
-    // 최상위 카테고리의 children을 제거함
-    delete categoryFamily[0].children;
+    // 최상위 카테고리 분리
     const updatedTopCategory: Category = categoryFamily[0];
 
-    // 캐시 내의 saves 카운트 증가
+    // 캐시 내에 저장 기록 불러옴
     let categoryCount: RecentCategoryList[] = await this.cacheManager.get(
       userInDb.id,
     );
@@ -476,26 +475,12 @@ export class ContentsService {
     // 캐시에 저장된 카테고리 카운트가 없다면, 새로운 배열을 만들어줌
     categoryCount = categoryCount ? categoryCount : [];
 
-    // 캐시에 저장된 카테고리 카운트가 있다면, 해당 카테고리 카운트를 증가시킴
-    if (
-      categoryCount.find(
-        (categoryCountInDb) =>
-          categoryCountInDb.categoryId === updatedTopCategory.id,
-      )
-    ) {
-      categoryCount.forEach((categoryCountInDb) => {
-        if (categoryCountInDb.categoryId === updatedTopCategory.id) {
-          categoryCountInDb.categorySaves++;
-        }
-      });
-    }
-    // 캐시에 저장된 카테고리 카운트가 없다면, 새로운 카테고리 카운트를 만들어주고 기존 것과 합쳐줌
-    else {
-      categoryCount.push({
-        categoryId: updatedTopCategory.id,
-        categorySaves: 1,
-      });
-    }
+    categoryCount.push({
+      categoryId: updatedTopCategory.id,
+      savedAt: new Date(),
+    });
+
+    // 캐시에 업데이트된 정보 저장
     this.cacheManager.set(userInDb.id, categoryCount, {
       ttl: categoryCountExpirationInCache,
     });

--- a/src/contents/contents.service.ts
+++ b/src/contents/contents.service.ts
@@ -803,7 +803,16 @@ export class CategoryService {
       const time: Date = new Date();
       time.setDate(time.getDate() - 2);
       if (recentCategoryList) {
-        recentCategoryList.filter((category) => time < category.savedAt);
+        recentCategoryList.filter((category) => {
+          console.log(
+            time,
+            ' ',
+            category.savedAt,
+            ' ',
+            time < category.savedAt,
+          );
+          return time < category.savedAt;
+        });
       }
       this.cacheManager.set(user.id, recentCategoryList, {
         ttl: categoryCountExpirationInCache,

--- a/src/contents/contents.service.ts
+++ b/src/contents/contents.service.ts
@@ -3,8 +3,6 @@ import {
   ConflictException,
   Injectable,
   NotFoundException,
-  CACHE_MANAGER,
-  Inject,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { EntityManager, Repository } from 'typeorm';
@@ -39,7 +37,6 @@ import { User } from '../users/entities/user.entity';
 import { Category } from './entities/category.entity';
 import { Content } from './entities/content.entity';
 import { CategoryRepository } from './repository/category.repository';
-import { Cache } from 'cache-manager';
 import * as fs from 'fs';
 
 @Injectable()
@@ -52,8 +49,6 @@ export class ContentsService {
     private readonly summaryService: SummaryService,
     @InjectRepository(Category)
     private readonly categories: CategoryRepository,
-    @Inject(CACHE_MANAGER)
-    private readonly cacheManager: Cache,
   ) {}
 
   async addContent(
@@ -624,8 +619,6 @@ export class CategoryService {
     private readonly categories: CategoryRepository,
     @InjectRepository(User)
     private readonly users: Repository<User>,
-    @Inject(CACHE_MANAGER)
-    private readonly cacheManager: Cache,
   ) {}
 
   async addCategory(

--- a/src/contents/contents.service.ts
+++ b/src/contents/contents.service.ts
@@ -1021,7 +1021,7 @@ export class CategoryService {
   ): RecentCategoryListWithSaveCount[] {
     const start: number = till - 10;
     const end: number = till;
-    for (let i = start; i < end; i++) {
+    for (let i = start; i < end && i < recentCategoryList.length; i++) {
       const inNewList = recentCategoriesWithSaveCount.find(
         (category) => category.categoryId === recentCategoryList[i].categoryId,
       );

--- a/src/contents/dtos/category.dto.ts
+++ b/src/contents/dtos/category.dto.ts
@@ -37,7 +37,7 @@ export class UpdateCategoryOutput extends CoreOutput {}
 
 export class DeleteCategoryOutput extends CoreOutput {}
 
-export class categoryNameAndSlug {
+export class CategoryNameAndSlug {
   @ApiProperty({ description: '카테고리 이름' })
   @IsString()
   categoryName: string;
@@ -45,4 +45,9 @@ export class categoryNameAndSlug {
   @ApiProperty({ description: '카테고리 슬러그' })
   @IsString()
   categorySlug: string;
+}
+
+export class CategoryTreeNode extends Category {
+  @ApiProperty({ description: '자식 카테고리' })
+  children?: CategoryTreeNode[];
 }

--- a/src/contents/dtos/category.dto.ts
+++ b/src/contents/dtos/category.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty, PickType } from '@nestjs/swagger';
 import { IsNumber, IsOptional, IsString } from 'class-validator';
-import { CoreOutput } from 'src/common/dtos/output.dto';
+import { CoreOutput } from '../../common/dtos/output.dto';
 import { Category } from '../entities/category.entity';
 
 export class AddCategoryBodyDto {

--- a/src/contents/dtos/category.dto.ts
+++ b/src/contents/dtos/category.dto.ts
@@ -52,7 +52,11 @@ export class CategoryTreeNode extends Category {
   children?: CategoryTreeNode[];
 }
 
-export class RecentCategoryList {
+export interface RecentCategoryList {
   categoryId: number;
-  savedAt: Date;
+  savedAt: number;
+}
+
+export interface RecentCategoryListWithSaveCount extends RecentCategoryList {
+  saveCount: number;
 }

--- a/src/contents/dtos/category.dto.ts
+++ b/src/contents/dtos/category.dto.ts
@@ -52,7 +52,7 @@ export class CategoryTreeNode extends Category {
   children?: CategoryTreeNode[];
 }
 
-export class CategoryCount {
+export class RecentCategoryList {
   categoryId: number;
-  categorySaves: number;
+  savedAt: Date;
 }

--- a/src/contents/dtos/category.dto.ts
+++ b/src/contents/dtos/category.dto.ts
@@ -51,3 +51,8 @@ export class CategoryTreeNode extends Category {
   @ApiProperty({ description: '자식 카테고리' })
   children?: CategoryTreeNode[];
 }
+
+export class CategoryCount {
+  categoryId: number;
+  categorySaves: number;
+}

--- a/src/contents/dtos/content.dto.ts
+++ b/src/contents/dtos/content.dto.ts
@@ -5,7 +5,7 @@ import {
   PickType,
 } from '@nestjs/swagger';
 import { IsNumber, IsOptional, IsString } from 'class-validator';
-import { CoreOutput } from 'src/common/dtos/output.dto';
+import { CoreOutput } from '../../common/dtos/output.dto';
 import { Content } from '../entities/content.entity';
 
 class ContentBodyExceptLink extends PartialType(

--- a/src/contents/dtos/load-personal-categories.dto.ts
+++ b/src/contents/dtos/load-personal-categories.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { CoreOutput } from 'src/common/dtos/output.dto';
-import { CategoryTreeNode } from 'src/contents/dtos/category.dto';
+import { CoreOutput } from '../../common/dtos/output.dto';
+import { CategoryTreeNode } from '../../contents/dtos/category.dto';
+import { Category } from '../entities/category.entity';
 
 export class LoadPersonalCategoriesOutput extends CoreOutput {
   @ApiProperty({
@@ -9,4 +10,12 @@ export class LoadPersonalCategoriesOutput extends CoreOutput {
     required: false,
   })
   categoriesTree?: CategoryTreeNode[];
+}
+
+export class LoadRecentCategoriesOutput extends CoreOutput {
+  @ApiProperty({
+    description: '최근 저장한 카테고리 목록',
+    type: [Category],
+  })
+  recentCategories?: Category[];
 }

--- a/src/contents/dtos/load-personal-categories.dto.ts
+++ b/src/contents/dtos/load-personal-categories.dto.ts
@@ -1,7 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { CoreOutput } from 'src/common/dtos/output.dto';
 import { CategoryTreeNode } from 'src/contents/dtos/category.dto';
-// import { Category } from 'src/contents/entities/category.entity';
 
 export class LoadPersonalCategoriesOutput extends CoreOutput {
   @ApiProperty({

--- a/src/contents/entities/category.entity.ts
+++ b/src/contents/entities/category.entity.ts
@@ -30,6 +30,7 @@ export class Category extends CoreEntity {
 
   @ManyToOne((type) => User, (user) => user.categories, {
     onDelete: 'CASCADE',
+    nullable: false,
   })
   user: User;
 

--- a/src/contents/entities/category.entity.ts
+++ b/src/contents/entities/category.entity.ts
@@ -37,8 +37,4 @@ export class Category extends CoreEntity {
   @ApiProperty({ description: 'Owner ID' })
   @RelationId((category: Category) => category.user)
   userId: number;
-
-  @ApiProperty({ description: 'Number of saves for that category' })
-  @Column({ default: 0 })
-  saves: number;
 }

--- a/src/contents/entities/category.entity.ts
+++ b/src/contents/entities/category.entity.ts
@@ -37,4 +37,8 @@ export class Category extends CoreEntity {
   @ApiProperty({ description: 'Owner ID' })
   @RelationId((category: Category) => category.user)
   userId: number;
+
+  @ApiProperty({ description: 'Number of saves for that category' })
+  @Column({ default: 0 })
+  saves: number;
 }

--- a/src/contents/repository/category.repository.ts
+++ b/src/contents/repository/category.repository.ts
@@ -1,7 +1,10 @@
-import { Repository } from 'typeorm';
+import { EntityManager, Repository } from 'typeorm';
 import { Category } from '../entities/category.entity';
 import { CategoryNameAndSlug, CategoryTreeNode } from '../dtos/category.dto';
-// import { AppDataSource } from 'src/database/ormconfig';
+import { User } from '../../users/entities/user.entity';
+import { ConflictException, NotFoundException } from '@nestjs/common';
+
+import * as fs from 'fs';
 
 export interface CategoryRepository extends Repository<Category> {
   // this: Repository<Category>;
@@ -15,19 +18,34 @@ export interface CategoryRepository extends Repository<Category> {
     categories: Category[],
     category: Category,
   ): CategoryTreeNode[];
+
+  getOrCreateCategory(
+    // link: string,
+    categoryName: string,
+    parentId: number,
+    userInDb: User,
+    queryRunnerManager: EntityManager,
+  ): Promise<Category>;
+
+  checkContentDuplicateAndAddCategorySaveLog(
+    link: string,
+    category: Category,
+    userInDb: User,
+  ): Promise<void>;
 }
 
 type CustomCategoryRepository = Pick<
   CategoryRepository,
-  'generateNameAndSlug' | 'generateCategoriesTree' | 'findCategoryFamily'
+  | 'generateNameAndSlug'
+  | 'generateCategoriesTree'
+  | 'findCategoryFamily'
+  | 'getOrCreateCategory'
+  | 'checkContentDuplicateAndAddCategorySaveLog'
 >;
 
 export const customCategoryRepositoryMethods: CustomCategoryRepository = {
   generateNameAndSlug(name: string): CategoryNameAndSlug {
-    const categoryName = name.trim().toLowerCase();
-    const categorySlug = categoryName.replace(/ /g, '-');
-
-    return { categoryName, categorySlug };
+    return generateNameAndSlug(name);
   },
 
   // make categories tree by parentId
@@ -39,55 +57,165 @@ export const customCategoryRepositoryMethods: CustomCategoryRepository = {
     categories: Category[],
     category: Category,
   ): CategoryTreeNode[] {
-    const topParentId = findTopParentCategory(categories, category);
-    const categoriesTree: CategoryTreeNode[] =
-      generateCategoriesTree(categories);
+    return findCategoryFamily(categories, category);
+  },
 
-    return categoriesTree.filter((category) => category.id === topParentId);
+  /**
+   * category를 생성하거나, 이미 존재하는 category를 가져옴
+   * content service의 method 내에서 중복되는 로직을 분리함
+   *
+   * @param categoryName
+   * @param parentId
+   * @param userInDb
+   * @param queryRunnerManager
+   * @returns category
+   */
+  async getOrCreateCategory(
+    categoryName: string,
+    parentId: number,
+    userInDb: User,
+    queryRunnerManager: EntityManager,
+  ): Promise<Category> {
+    // generate category name and slug
+    const { categoryName: refinedCategoryName, categorySlug } =
+      generateNameAndSlug(categoryName);
+
+    // if parent id is undefined, set it to null to avoid bug caused by type mismatch
+    if (!parentId) {
+      parentId = null;
+    } else {
+      // category depth should be 3
+      let currentParentId = parentId;
+      let parentCategory: Category = null;
+      for (let i = 0; i < 2; i++) {
+        parentCategory = await queryRunnerManager.findOne(Category, {
+          where: { id: currentParentId },
+        });
+        if (i == 1 && parentCategory.parentId != null) {
+          throw new ConflictException('Category depth should be 3');
+        }
+        currentParentId = parentCategory.parentId;
+      }
+    }
+    // check if category exists in user's categories
+    let category: Category = userInDb.categories.find(
+      (category) =>
+        category.slug === categorySlug && category.parentId === parentId,
+    );
+
+    // if category doesn't exist, create it
+    if (!category) {
+      // if parent id exists, get parent category
+      const parentCategory: Category = parentId
+        ? await queryRunnerManager.findOne(Category, {
+            where: { id: parentId },
+          })
+        : null;
+      // if parent category doesn't exist, throw error
+      if (!parentCategory && parentId) {
+        throw new NotFoundException('Parent category not found');
+      }
+
+      category = await queryRunnerManager.save(
+        queryRunnerManager.create(Category, {
+          slug: categorySlug,
+          name: refinedCategoryName,
+          parentId: parentCategory ? parentCategory.id : null,
+          user: userInDb,
+        }),
+      );
+
+      userInDb.categories.push(category);
+      await queryRunnerManager.save(userInDb);
+    }
+
+    return category;
+  },
+
+  /**
+   * 대 카테고리를 기준으로 중복 체크하고,
+   * 최상위 카테고리의 카운트를 올려줌
+   *
+   * @param link
+   * @param category
+   * @param userInDb
+   */
+  async checkContentDuplicateAndAddCategorySaveLog(
+    link: string,
+    category: Category,
+    userInDb: User,
+  ): Promise<void> {
+    // 최상위 카테고리부터 시작해서 하위 카테고리까지의 그룹을 찾아옴
+    const categoryFamily = findCategoryFamily(userInDb.categories, category);
+
+    /*
+     * 카테고리의 중복을 체크하고, 중복이 없다면 최상위 카테고리의 count를 증가시킴
+     */
+
+    // flat categoryFamily with children
+    categoryFamily.reduce((acc, cur) => {
+      acc.push(cur);
+      if (cur.children) {
+        acc.push(cur.children.reduce);
+      }
+      return acc;
+    }, []);
+    const flatDeep = (arr, d) => {
+      return d > 0
+        ? arr.reduce((acc, cur) => {
+            const forConcat = [cur];
+            return acc.concat(
+              cur.children
+                ? forConcat.concat(flatDeep(cur.children, d - 1))
+                : cur,
+            );
+          }, [])
+        : arr.slice();
+    };
+
+    const flatCategoryFamily = flatDeep(categoryFamily, Infinity);
+
+    const contentThatSameLinkAndCategory = userInDb.contents.find(
+      (contentInFilter) =>
+        contentInFilter.link === link &&
+        flatCategoryFamily.filter(
+          (categoryInFamily) =>
+            categoryInFamily.id === contentInFilter.category.id,
+        ).length > 0,
+    );
+    if (contentThatSameLinkAndCategory) {
+      throw new ConflictException(
+        'Content with that link already exists in same category family.',
+      );
+    }
+
+    /*
+     * 최상위 카테고리의 count를 증가시킨 후,
+     * 해당 카테고리의 저장 기록을 유저 로그 파일에 추가함
+     */
+
+    // 최상위 카테고리 분리
+    const updatedTopCategory: Category = categoryFamily[0];
+
+    // 최상위 카테고리의 count 증가
+    const log = `{"categoryId": ${
+      updatedTopCategory.id
+    },"savedAt": ${new Date().getTime()}}\n`;
+
+    // 유저 로그 파일에 로그 추가
+    fs.appendFileSync(
+      `${__dirname}/../../../user_logs/${userInDb.id}.txt`,
+      log,
+    );
   },
 };
 
-// export const customCategoryRepository = AppDataSource.getRepository(
-//   Category,
-// ).extend({
-//   generateNameAndSlug(name: string): CategoryNameAndSlug {
-//     const categoryName = name.trim().toLowerCase();
-//     const categorySlug = categoryName.replace(/ /g, '-');
+const generateNameAndSlug = (name: string): CategoryNameAndSlug => {
+  const categoryName = name.trim().toLowerCase();
+  const categorySlug = categoryName.replace(/ /g, '-');
 
-//     return { categoryName, categorySlug };
-//   },
-
-//   // make categories tree by parentId
-//   generateCategoriesTree(categories: Category[]): CategoryTreeNode[] {
-//     const categoriesTree: CategoryTreeNode[] = categories;
-//     categoriesTree.reduce((acc, cur) => {
-//       if (cur.parentId) {
-//         const parent = categoriesTree.find(
-//           (category) => category.id === cur.parentId,
-//         );
-//         if (parent) {
-//           if (!parent.children) parent.children = [];
-//           parent.children.push(cur);
-//           categoriesTree.splice(categoriesTree.indexOf(cur), 1);
-//         }
-//       }
-//       return acc;
-//     });
-
-//     return categoriesTree;
-//   },
-
-//   findTopParentCategory(categories: Category[], category: Category): number {
-//     if (category.parentId) {
-//       const parent = categories.find((c) => c.id === category.parentId);
-//       if (parent) {
-//         return findTopParentCategory(categories, parent);
-//       }
-//     } else {
-//       return category.id;
-//     }
-//   },
-// });
+  return { categoryName, categorySlug };
+};
 
 const generateCategoriesTree = (categories: Category[]): CategoryTreeNode[] => {
   const categoriesTree: CategoryTreeNode[] = categories;
@@ -106,6 +234,16 @@ const generateCategoriesTree = (categories: Category[]): CategoryTreeNode[] => {
   }
 
   return categoriesTree;
+};
+
+const findCategoryFamily = (
+  categories: Category[],
+  category: Category,
+): CategoryTreeNode[] => {
+  const topParentId = findTopParentCategory(categories, category);
+  const categoriesTree: CategoryTreeNode[] = generateCategoriesTree(categories);
+
+  return categoriesTree.filter((category) => category.id === topParentId);
 };
 
 const findTopParentCategory = (

--- a/src/contents/repository/category.repository.ts
+++ b/src/contents/repository/category.repository.ts
@@ -1,17 +1,17 @@
 import { Repository } from 'typeorm';
 import { Category } from '../entities/category.entity';
-import { categoryNameAndSlug } from '../dtos/category.dto';
+import { CategoryNameAndSlug } from '../dtos/category.dto';
 
 export interface CategoryRepository extends Repository<Category> {
-  this: Repository<Category>;
+  // this: Repository<Category>;
 
-  generateNameAndSlug(name: string): categoryNameAndSlug;
+  generateNameAndSlug(name: string): CategoryNameAndSlug;
 }
 
 type CustomCategoryRepository = Pick<CategoryRepository, 'generateNameAndSlug'>;
 
 export const customCategoryRepositoryMethods: CustomCategoryRepository = {
-  generateNameAndSlug(name: string): categoryNameAndSlug {
+  generateNameAndSlug(name: string): CategoryNameAndSlug {
     const categoryName = name.trim().toLowerCase();
     const categorySlug = categoryName.replace(/ /g, '-');
 

--- a/src/contents/repository/category.repository.ts
+++ b/src/contents/repository/category.repository.ts
@@ -1,6 +1,7 @@
 import { Repository } from 'typeorm';
 import { Category } from '../entities/category.entity';
 import { CategoryNameAndSlug, CategoryTreeNode } from '../dtos/category.dto';
+// import { AppDataSource } from 'src/database/ormconfig';
 
 export interface CategoryRepository extends Repository<Category> {
   // this: Repository<Category>;
@@ -9,11 +10,16 @@ export interface CategoryRepository extends Repository<Category> {
 
   // make categories tree by parentId
   generateCategoriesTree(categories: Category[]): CategoryTreeNode[];
+
+  findCategoryFamily(
+    categories: Category[],
+    category: Category,
+  ): CategoryTreeNode[];
 }
 
 type CustomCategoryRepository = Pick<
   CategoryRepository,
-  'generateNameAndSlug' | 'generateCategoriesTree'
+  'generateNameAndSlug' | 'generateCategoriesTree' | 'findCategoryFamily'
 >;
 
 export const customCategoryRepositoryMethods: CustomCategoryRepository = {
@@ -26,21 +32,92 @@ export const customCategoryRepositoryMethods: CustomCategoryRepository = {
 
   // make categories tree by parentId
   generateCategoriesTree(categories: Category[]): CategoryTreeNode[] {
-    const categoriesTree: CategoryTreeNode[] = categories;
-    categoriesTree.reduce((acc, cur) => {
-      if (cur.parentId) {
-        const parent = categoriesTree.find(
-          (category) => category.id === cur.parentId,
-        );
-        if (parent) {
-          if (!parent.children) parent.children = [];
-          parent.children.push(cur);
-          categoriesTree.splice(categoriesTree.indexOf(cur), 1);
-        }
-      }
-      return acc;
-    });
-
-    return categoriesTree;
+    return generateCategoriesTree(categories);
   },
+
+  findCategoryFamily(
+    categories: Category[],
+    category: Category,
+  ): CategoryTreeNode[] {
+    const topParentId = findTopParentCategory(categories, category);
+    const categoriesTree: CategoryTreeNode[] =
+      generateCategoriesTree(categories);
+
+    return categoriesTree.filter((category) => category.id === topParentId);
+  },
+};
+
+// export const customCategoryRepository = AppDataSource.getRepository(
+//   Category,
+// ).extend({
+//   generateNameAndSlug(name: string): CategoryNameAndSlug {
+//     const categoryName = name.trim().toLowerCase();
+//     const categorySlug = categoryName.replace(/ /g, '-');
+
+//     return { categoryName, categorySlug };
+//   },
+
+//   // make categories tree by parentId
+//   generateCategoriesTree(categories: Category[]): CategoryTreeNode[] {
+//     const categoriesTree: CategoryTreeNode[] = categories;
+//     categoriesTree.reduce((acc, cur) => {
+//       if (cur.parentId) {
+//         const parent = categoriesTree.find(
+//           (category) => category.id === cur.parentId,
+//         );
+//         if (parent) {
+//           if (!parent.children) parent.children = [];
+//           parent.children.push(cur);
+//           categoriesTree.splice(categoriesTree.indexOf(cur), 1);
+//         }
+//       }
+//       return acc;
+//     });
+
+//     return categoriesTree;
+//   },
+
+//   findTopParentCategory(categories: Category[], category: Category): number {
+//     if (category.parentId) {
+//       const parent = categories.find((c) => c.id === category.parentId);
+//       if (parent) {
+//         return findTopParentCategory(categories, parent);
+//       }
+//     } else {
+//       return category.id;
+//     }
+//   },
+// });
+
+const generateCategoriesTree = (categories: Category[]): CategoryTreeNode[] => {
+  const categoriesTree: CategoryTreeNode[] = categories;
+  for (let i = 0; i < categoriesTree.length; i++) {
+    if (categoriesTree[i].parentId) {
+      const parent = categoriesTree.find(
+        (category) => category.id === categoriesTree[i].parentId,
+      );
+      if (parent) {
+        if (!parent.children) parent.children = [];
+        parent.children.push(categoriesTree[i]);
+        categoriesTree.splice(i, 1);
+        i--;
+      }
+    }
+  }
+
+  return categoriesTree;
+};
+
+const findTopParentCategory = (
+  categories: Category[],
+  category: Category,
+): number => {
+  if (category.parentId) {
+    const parent = categories.find((c) => c.id === category.parentId);
+    if (parent) {
+      return findTopParentCategory(categories, parent);
+    }
+  } else {
+    return category.id;
+  }
 };

--- a/src/contents/repository/category.repository.ts
+++ b/src/contents/repository/category.repository.ts
@@ -1,14 +1,20 @@
 import { Repository } from 'typeorm';
 import { Category } from '../entities/category.entity';
-import { CategoryNameAndSlug } from '../dtos/category.dto';
+import { CategoryNameAndSlug, CategoryTreeNode } from '../dtos/category.dto';
 
 export interface CategoryRepository extends Repository<Category> {
   // this: Repository<Category>;
 
   generateNameAndSlug(name: string): CategoryNameAndSlug;
+
+  // make categories tree by parentId
+  generateCategoriesTree(categories: Category[]): CategoryTreeNode[];
 }
 
-type CustomCategoryRepository = Pick<CategoryRepository, 'generateNameAndSlug'>;
+type CustomCategoryRepository = Pick<
+  CategoryRepository,
+  'generateNameAndSlug' | 'generateCategoriesTree'
+>;
 
 export const customCategoryRepositoryMethods: CustomCategoryRepository = {
   generateNameAndSlug(name: string): CategoryNameAndSlug {
@@ -16,5 +22,25 @@ export const customCategoryRepositoryMethods: CustomCategoryRepository = {
     const categorySlug = categoryName.replace(/ /g, '-');
 
     return { categoryName, categorySlug };
+  },
+
+  // make categories tree by parentId
+  generateCategoriesTree(categories: Category[]): CategoryTreeNode[] {
+    const categoriesTree: CategoryTreeNode[] = categories;
+    categoriesTree.reduce((acc, cur) => {
+      if (cur.parentId) {
+        const parent = categoriesTree.find(
+          (category) => category.id === cur.parentId,
+        );
+        if (parent) {
+          if (!parent.children) parent.children = [];
+          parent.children.push(cur);
+          categoriesTree.splice(categoriesTree.indexOf(cur), 1);
+        }
+      }
+      return acc;
+    });
+
+    return categoriesTree;
   },
 };

--- a/src/contents/repository/category.repository.ts
+++ b/src/contents/repository/category.repository.ts
@@ -221,6 +221,23 @@ const generateCategoriesTree = (categories: Category[]): CategoryTreeNode[] => {
   const categoriesTree: CategoryTreeNode[] = categories;
   for (let i = 0; i < categoriesTree.length; i++) {
     if (categoriesTree[i].parentId) {
+      // 세세부 카테고리 우선 작업
+      const parent = categoriesTree.find(
+        (category) =>
+          category.id === categoriesTree[i].parentId && category.parentId,
+      );
+      if (parent) {
+        if (!parent.children) parent.children = [];
+        parent.children.push(categoriesTree[i]);
+        categoriesTree.splice(i, 1);
+        i--;
+      }
+    }
+  }
+
+  for (let i = 0; i < categoriesTree.length; i++) {
+    if (categoriesTree[i].parentId) {
+      // 중간 카테고리 작업(세부 카테고리)
       const parent = categoriesTree.find(
         (category) => category.id === categoriesTree[i].parentId,
       );

--- a/src/database/migrations/1673454056466-change_category_entity.ts
+++ b/src/database/migrations/1673454056466-change_category_entity.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class changeCategoryEntity1673454056466 implements MigrationInterface {
+    name = 'changeCategoryEntity1673454056466'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "category" DROP CONSTRAINT "FK_32b856438dffdc269fa84434d9f"`);
+        await queryRunner.query(`ALTER TABLE "category" ALTER COLUMN "userId" SET NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "category" ADD CONSTRAINT "FK_32b856438dffdc269fa84434d9f" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "category" DROP CONSTRAINT "FK_32b856438dffdc269fa84434d9f"`);
+        await queryRunner.query(`ALTER TABLE "category" ALTER COLUMN "userId" DROP NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "category" ADD CONSTRAINT "FK_32b856438dffdc269fa84434d9f" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+    }
+
+}

--- a/src/database/migrations/1673459256843-change_category_entity.ts
+++ b/src/database/migrations/1673459256843-change_category_entity.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class changeCategoryEntity1673459256843 implements MigrationInterface {
+    name = 'changeCategoryEntity1673459256843'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "category" ADD "saves" integer NOT NULL DEFAULT '0'`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "category" DROP COLUMN "saves"`);
+    }
+
+}

--- a/src/database/migrations/1674029762201-remove_saves_column.ts
+++ b/src/database/migrations/1674029762201-remove_saves_column.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class removeSavesColumn1674029762201 implements MigrationInterface {
+    name = 'removeSavesColumn1674029762201'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "category" DROP COLUMN "saves"`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "category" ADD "saves" integer NOT NULL DEFAULT '0'`);
+    }
+
+}

--- a/src/database/ormconfig.ts
+++ b/src/database/ormconfig.ts
@@ -1,6 +1,11 @@
 import { DataSource, DataSourceOptions } from 'typeorm';
-import * as dotenv from 'dotenv';
 
+/**
+ * 아래 2줄은 로컬에서만 사용하는 코드이다.(.env.dev 파일을 사용하기 위함)
+ * 배포 서버에선 docker container 내부에 이미 환경변수가 설정되어 있기 때문에
+ * 아래 2줄은 주석처리한다.
+ */
+// import * as dotenv from 'dotenv';
 // dotenv.config({ path: __dirname + '/../../.env.dev' });
 
 export const AppDataSource = new DataSource({

--- a/src/mail/mail.service.spec.ts
+++ b/src/mail/mail.service.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { CONFIG_OPTIONS } from 'src/common/common.constants';
+import { CONFIG_OPTIONS } from '../common/common.constants';
 import { MailService } from './mail.service';
 
 describe('MailService', () => {

--- a/src/mail/mail.service.ts
+++ b/src/mail/mail.service.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import { EmailVar, MailModuleOptions } from './mail.interface';
 import axios from 'axios';
 import * as FormData from 'form-data';
-import { CONFIG_OPTIONS } from 'src/common/common.constants';
+import { CONFIG_OPTIONS } from '../common/common.constants';
 
 @Injectable()
 export class MailService {

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,7 +22,7 @@ async function bootstrap() {
   const config = new DocumentBuilder()
     .setTitle('Quickchive')
     .setDescription('The API description')
-    .setVersion('0.1')
+    .setVersion('1.0.0')
     .addTag('Minimally Viable Product Version')
     .addBearerAuth(
       {

--- a/src/summary/summary.service.spec.ts
+++ b/src/summary/summary.service.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { CONFIG_OPTIONS } from 'src/common/common.constants';
+import { CONFIG_OPTIONS } from '../common/common.constants';
 import { SummaryService } from './summary.service';
 
 describe('SummaryService', () => {

--- a/src/summary/summary.service.ts
+++ b/src/summary/summary.service.ts
@@ -10,7 +10,7 @@ import {
   SummarizeDocumentInput,
   SummarizeDocumentOutput,
 } from './dtos/summary-content.dto';
-import { CONFIG_OPTIONS } from 'src/common/common.constants';
+import { CONFIG_OPTIONS } from '../common/common.constants';
 import * as cheerio from 'cheerio';
 import { logger } from 'src/common/logger';
 

--- a/src/users/dtos/edit-profile.dto.ts
+++ b/src/users/dtos/edit-profile.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty, PartialType, PickType } from '@nestjs/swagger';
 import { IsString } from 'class-validator';
-import { CoreOutput } from 'src/common/dtos/output.dto';
+import { CoreOutput } from '../../common/dtos/output.dto';
 import { User } from '../entities/user.entity';
 
 export class EditProfileOutput extends CoreOutput {}

--- a/src/users/dtos/load-personal-categories.dto.ts
+++ b/src/users/dtos/load-personal-categories.dto.ts
@@ -1,12 +1,13 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { CoreOutput } from 'src/common/dtos/output.dto';
-import { Category } from 'src/contents/entities/category.entity';
+import { CategoryTreeNode } from 'src/contents/dtos/category.dto';
+// import { Category } from 'src/contents/entities/category.entity';
 
 export class LoadPersonalCategoriesOutput extends CoreOutput {
   @ApiProperty({
     description: '카테고리 목록',
-    type: [Category],
+    type: [CategoryTreeNode],
     required: false,
   })
-  categories?: Category[];
+  categoriesTree?: CategoryTreeNode[];
 }

--- a/src/users/dtos/load-personal-collections.dto.ts
+++ b/src/users/dtos/load-personal-collections.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { Collection } from 'src/collections/entities/collection.entity';
-import { CoreOutput } from 'src/common/dtos/output.dto';
+import { Collection } from '../../collections/entities/collection.entity';
+import { CoreOutput } from '../../common/dtos/output.dto';
 
 export class LoadPersonalCollectionsOutput extends CoreOutput {
   @ApiProperty({

--- a/src/users/dtos/load-personal-contents.dto.ts
+++ b/src/users/dtos/load-personal-contents.dto.ts
@@ -1,7 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { Collection } from 'src/collections/entities/collection.entity';
-import { CoreOutput } from 'src/common/dtos/output.dto';
-import { Content } from 'src/contents/entities/content.entity';
+import { CoreOutput } from '../../common/dtos/output.dto';
+import { Content } from '../../contents/entities/content.entity';
 
 export class LoadPersonalContentsOutput extends CoreOutput {
   @ApiProperty({

--- a/src/users/dtos/reset-password.dto.ts
+++ b/src/users/dtos/reset-password.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty, IntersectionType, PickType } from '@nestjs/swagger';
-import { CoreOutput } from 'src/common/dtos/output.dto';
+import { CoreOutput } from '../../common/dtos/output.dto';
 import { User } from '../entities/user.entity';
 
 class passwordForResetPassword extends PickType(User, ['password']) {}

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -22,7 +22,7 @@ import { TransactionInterceptor } from 'src/common/interceptors/transaction.inte
 import { TransactionManager } from 'src/common/transaction.decorator';
 import { EntityManager } from 'typeorm';
 import { EditProfileInput, EditProfileOutput } from './dtos/edit-profile.dto';
-import { LoadPersonalCategoriesOutput } from './dtos/load-personal-categories.dto';
+import { LoadPersonalCategoriesOutput } from '../contents/dtos/load-personal-categories.dto';
 import { LoadPersonalCollectionsOutput } from './dtos/load-personal-collections.dto';
 import {
   LoadFavoritesOutput,
@@ -158,20 +158,20 @@ export class UsersController {
   //   return await this.usersService.loadPersonalCollections(user, +categoryId);
   // }
 
-  @ApiOperation({
-    summary: '자신의 카테고리 목록 조회',
-    description: '자신의 카테고리 목록을 조회하는 메서드',
-  })
-  @ApiOkResponse({
-    description: '카테고리 목록을 반환한다.',
-    type: LoadPersonalCategoriesOutput,
-  })
-  @ApiBearerAuth('Authorization')
-  @UseGuards(JwtAuthGuard)
-  @Get('load-categories')
-  async loadPersonalCategories(
-    @AuthUser() user: User,
-  ): Promise<LoadPersonalCategoriesOutput> {
-    return await this.usersService.loadPersonalCategories(user);
-  }
+  // @ApiOperation({
+  //   summary: '자신의 카테고리 목록 조회',
+  //   description: '자신의 카테고리 목록을 조회하는 메서드',
+  // })
+  // @ApiOkResponse({
+  //   description: '카테고리 목록을 반환한다.',
+  //   type: LoadPersonalCategoriesOutput,
+  // })
+  // @ApiBearerAuth('Authorization')
+  // @UseGuards(JwtAuthGuard)
+  // @Get('load-categories')
+  // async loadPersonalCategories(
+  //   @AuthUser() user: User,
+  // ): Promise<LoadPersonalCategoriesOutput> {
+  //   return await this.usersService.loadPersonalCategories(user);
+  // }
 }

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -22,8 +22,6 @@ import { TransactionInterceptor } from 'src/common/interceptors/transaction.inte
 import { TransactionManager } from 'src/common/transaction.decorator';
 import { EntityManager } from 'typeorm';
 import { EditProfileInput, EditProfileOutput } from './dtos/edit-profile.dto';
-import { LoadPersonalCategoriesOutput } from '../contents/dtos/load-personal-categories.dto';
-import { LoadPersonalCollectionsOutput } from './dtos/load-personal-collections.dto';
 import {
   LoadFavoritesOutput,
   LoadPersonalContentsOutput,
@@ -156,22 +154,5 @@ export class UsersController {
   //   @Query('categoryId') categoryId: number,
   // ): Promise<LoadPersonalCollectionsOutput> {
   //   return await this.usersService.loadPersonalCollections(user, +categoryId);
-  // }
-
-  // @ApiOperation({
-  //   summary: '자신의 카테고리 목록 조회',
-  //   description: '자신의 카테고리 목록을 조회하는 메서드',
-  // })
-  // @ApiOkResponse({
-  //   description: '카테고리 목록을 반환한다.',
-  //   type: LoadPersonalCategoriesOutput,
-  // })
-  // @ApiBearerAuth('Authorization')
-  // @UseGuards(JwtAuthGuard)
-  // @Get('load-categories')
-  // async loadPersonalCategories(
-  //   @AuthUser() user: User,
-  // ): Promise<LoadPersonalCategoriesOutput> {
-  //   return await this.usersService.loadPersonalCategories(user);
   // }
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -105,8 +105,6 @@ export class UsersService {
         );
       }
 
-      console.log(contents);
-
       return {
         contents,
       };

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -174,39 +174,4 @@ export class UsersService {
   //     throw e;
   //   }
   // }
-
-  // async loadPersonalCategories(
-  //   user: User,
-  // ): Promise<LoadPersonalCategoriesOutput> {
-  //   try {
-  //     const { categories } = await this.users.findOne({
-  //       where: { id: user.id },
-  //       relations: {
-  //         categories: true,
-  //       },
-  //     });
-
-  //     // make categories tree by parentid
-  //     const categoriesTree: CategoryTreeNode[] = categories;
-  //     categoriesTree.reduce((acc, cur) => {
-  //       if (cur.parentId) {
-  //         const parent = categoriesTree.find(
-  //           (category) => category.id === cur.parentId,
-  //         );
-  //         if (parent) {
-  //           if (!parent.children) parent.children = [];
-  //           parent.children.push(cur);
-  //           categoriesTree.splice(categoriesTree.indexOf(cur), 1);
-  //         }
-  //       }
-  //       return acc;
-  //     });
-
-  //     return {
-  //       categoriesTree,
-  //     };
-  //   } catch (e) {
-  //     throw e;
-  //   }
-  // }
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,6 +1,5 @@
 import {
   CACHE_MANAGER,
-  HttpException,
   Inject,
   Injectable,
   NotFoundException,
@@ -21,8 +20,7 @@ import {
 } from './dtos/reset-password.dto';
 import { User } from './entities/user.entity';
 import { Cache } from 'cache-manager';
-import { LoadPersonalCollectionsOutput } from './dtos/load-personal-collections.dto';
-import { Collection } from 'src/collections/entities/collection.entity';
+import { CategoryTreeNode } from 'src/contents/dtos/category.dto';
 
 @Injectable()
 export class UsersService {
@@ -190,8 +188,24 @@ export class UsersService {
         },
       });
 
+      // make categories tree by parentid
+      const categoriesTree: CategoryTreeNode[] = categories;
+      categoriesTree.reduce((acc, cur) => {
+        if (cur.parentId) {
+          const parent = categoriesTree.find(
+            (category) => category.id === cur.parentId,
+          );
+          if (parent) {
+            if (!parent.children) parent.children = [];
+            parent.children.push(cur);
+            categoriesTree.splice(categoriesTree.indexOf(cur), 1);
+          }
+        }
+        return acc;
+      });
+
       return {
-        categories,
+        categoriesTree,
       };
     } catch (e) {
       throw e;

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -9,7 +9,6 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Content } from 'src/contents/entities/content.entity';
 import { EntityManager, Repository } from 'typeorm';
 import { EditProfileInput, EditProfileOutput } from './dtos/edit-profile.dto';
-import { LoadPersonalCategoriesOutput } from './dtos/load-personal-categories.dto';
 import {
   LoadFavoritesOutput,
   LoadPersonalContentsOutput,
@@ -20,7 +19,6 @@ import {
 } from './dtos/reset-password.dto';
 import { User } from './entities/user.entity';
 import { Cache } from 'cache-manager';
-import { CategoryTreeNode } from 'src/contents/dtos/category.dto';
 
 @Injectable()
 export class UsersService {
@@ -177,38 +175,38 @@ export class UsersService {
   //   }
   // }
 
-  async loadPersonalCategories(
-    user: User,
-  ): Promise<LoadPersonalCategoriesOutput> {
-    try {
-      const { categories } = await this.users.findOne({
-        where: { id: user.id },
-        relations: {
-          categories: true,
-        },
-      });
+  // async loadPersonalCategories(
+  //   user: User,
+  // ): Promise<LoadPersonalCategoriesOutput> {
+  //   try {
+  //     const { categories } = await this.users.findOne({
+  //       where: { id: user.id },
+  //       relations: {
+  //         categories: true,
+  //       },
+  //     });
 
-      // make categories tree by parentid
-      const categoriesTree: CategoryTreeNode[] = categories;
-      categoriesTree.reduce((acc, cur) => {
-        if (cur.parentId) {
-          const parent = categoriesTree.find(
-            (category) => category.id === cur.parentId,
-          );
-          if (parent) {
-            if (!parent.children) parent.children = [];
-            parent.children.push(cur);
-            categoriesTree.splice(categoriesTree.indexOf(cur), 1);
-          }
-        }
-        return acc;
-      });
+  //     // make categories tree by parentid
+  //     const categoriesTree: CategoryTreeNode[] = categories;
+  //     categoriesTree.reduce((acc, cur) => {
+  //       if (cur.parentId) {
+  //         const parent = categoriesTree.find(
+  //           (category) => category.id === cur.parentId,
+  //         );
+  //         if (parent) {
+  //           if (!parent.children) parent.children = [];
+  //           parent.children.push(cur);
+  //           categoriesTree.splice(categoriesTree.indexOf(cur), 1);
+  //         }
+  //       }
+  //       return acc;
+  //     });
 
-      return {
-        categoriesTree,
-      };
-    } catch (e) {
-      throw e;
-    }
-  }
+  //     return {
+  //       categoriesTree,
+  //     };
+  //   } catch (e) {
+  //     throw e;
+  //   }
+  // }
 }

--- a/user_logs/1.txt
+++ b/user_logs/1.txt
@@ -1,3 +1,8 @@
-{"categoryId": 16,"savedAt": 1674218419211}
-{"categoryId": 16,"savedAt": 1674218423926}
-{"categoryId": 13,"savedAt": 1674218427094}
+{"categoryId": 13,"savedAt": 1674228254021}
+{"categoryId": 13,"savedAt": 1674228257056}
+{"categoryId": 16,"savedAt": 1674228317271}
+{"categoryId": 16,"savedAt": 1674646370377}
+{"categoryId": 14,"savedAt": 1674646406408}
+{"categoryId": 16,"savedAt": 1674647076221}
+{"categoryId": 14,"savedAt": 1674647103041}
+{"categoryId": 16,"savedAt": 1674648777990}

--- a/user_logs/1.txt
+++ b/user_logs/1.txt
@@ -1,0 +1,3 @@
+{"categoryId": 16,"savedAt": 1674218419211}
+{"categoryId": 16,"savedAt": 1674218423926}
+{"categoryId": 13,"savedAt": 1674218427094}


### PR DESCRIPTION
#147 작업 중 작업량이 꽤 되는 것 같아서 나눠서 테스트 배포하고자 중간 점검용으로 merge하고자 합니다!
@oseunghyun @sozimm 
## 작업 내용
콘텐츠 저장 시 띄워줄 카테고리 n번 자리 결정 로직
세부/세세부를 초과한 depth 불가능하도록

## 추가된 API
GET /api/category/load-categories
자신의 카테고리 목록 조회

GET /api/category/load-recent-categories
최근 저장한 카테고리 조회

## 삭제된 API
GET /api/users/load-categories
자신의 카테고리 목록 조회

## 변경사항
GET /api/users/load-categories -> GET /api/category/load-categories api path 변경
GET /api/category/load-categories 자신의 카테고리 목록 조회 response body 변경 (categories -> categoriesTree)