### PR TITLE
Feature/#164 부모 카테고리 id property의 swagger docs 옵션 개선

### DIFF
--- a/src/contents/dtos/content.dto.ts
+++ b/src/contents/dtos/content.dto.ts
@@ -19,7 +19,7 @@ class ContentBodyExceptLink extends PartialType(
   @ApiProperty({
     description: '부모 카테고리 id',
     example: 1,
-    nullable: true,
+    required: false,
   })
   @IsNumber()
   @IsOptional()


### PR DESCRIPTION
required: false 옵션을 추가해서 필수값이 아님을 명시함