### PR TITLE
Feature/#177 로그인 유지 기간 변경

### DIFF
--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -9,10 +9,9 @@ import { JwtStrategy } from './jwt/jwt.strategy';
 import * as redisStore from 'cache-manager-redis-store';
 import { GoogleStrategy } from './passport/google/google.strategy';
 import { customJwtService } from './jwt/jwt.service';
-import { ONEMONTH } from './jwt/jwt.payload';
+import { TWOHOUR } from './jwt/jwt.payload';
 
-const accessTokenExpiration = '10m';
-export const refreshTokenExpiration = ONEMONTH;
+const accessTokenExpiration = TWOHOUR;
 export const refreshTokenExpirationInCache = 60 * 60 * 24 * 30;
 export const refreshTokenExpirationInCacheShortVersion = 60 * 60 * 24 * 2;
 export const verifyEmailExpiration = 60 * 5;

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -32,7 +32,7 @@ import { sendPasswordResetEmailOutput } from './dtos/send-password-reset-email.d
 import { RefreshTokenDto, RefreshTokenOutput } from './dtos/token.dto';
 import { ValidateUserDto, ValidateUserOutput } from './dtos/validate-user.dto';
 import { VerifyEmailOutput } from './dtos/verify-email.dto';
-import { ONEMONTH, Payload } from './jwt/jwt.payload';
+import { ONEYEAR, Payload } from './jwt/jwt.payload';
 import { Cache } from 'cache-manager';
 import { v4 as uuidv4 } from 'uuid';
 import axios from 'axios';
@@ -169,7 +169,7 @@ export class AuthService {
     }
 
     const user = await this.users.findOneBy({ id: decoded.sub });
-    const auto_login: boolean = decoded.period === ONEMONTH;
+    const auto_login: boolean = decoded.period === ONEYEAR;
 
     if (!user) {
       throw new NotFoundException('User not found');

--- a/src/auth/jwt/jwt.payload.ts
+++ b/src/auth/jwt/jwt.payload.ts
@@ -4,5 +4,6 @@ export class Payload {
   sub!: number; // userId
 }
 
-export const ONEMONTH = '30d';
+export const ONEYEAR = '1y';
+export const ONEDAY = '1d';
 export const TWOHOUR = '2h';

--- a/src/auth/jwt/jwt.service.ts
+++ b/src/auth/jwt/jwt.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { JwtService, JwtVerifyOptions } from '@nestjs/jwt';
-import { refreshTokenExpiration } from '../auth.module';
-import { ONEMONTH, Payload, TWOHOUR } from './jwt.payload';
+import { ONEDAY, ONEYEAR, Payload } from './jwt.payload';
 
 @Injectable()
 export class customJwtService {
@@ -16,7 +15,7 @@ export class customJwtService {
   }
 
   createPayload(email: string, autoLogin: boolean, sub: number): Payload {
-    const period: string = autoLogin ? ONEMONTH : TWOHOUR;
+    const period: string = autoLogin ? ONEYEAR : ONEDAY;
 
     const payload: Payload = { email, period, sub };
 
@@ -24,8 +23,7 @@ export class customJwtService {
   }
 
   generateRefreshToken(payload: Payload): string {
-    const expiresIn: string =
-      payload.period === ONEMONTH ? refreshTokenExpiration : TWOHOUR;
+    const expiresIn: string = payload.period === ONEYEAR ? ONEYEAR : ONEDAY;
     return this.jwtService.sign(payload, {
       secret: process.env.JWT_REFRESH_TOKEN_PRIVATE_KEY,
       expiresIn,


### PR DESCRIPTION
# 로그인 유지 기간 변경

1년 동안 들어오지 않아도 로그인이 유지되는 편이 나을 것 같다고 의견이 모아져
기간을 1년으로 변경

## 변경 내용
- access token 만료 기간
   - 2 hour
- refresh token 만료기간
    - 자동로그인 O : 1 year - 자동로그인 X : 1 day