### PR TITLE
Feature/#197 link에 http가 달려있지 않은 경우 추가 후 크롤링

### DIFF
--- a/src/contents/util/content.util.ts
+++ b/src/contents/util/content.util.ts
@@ -10,9 +10,8 @@ export class ContentUtil {
     let description: string | undefined = '';
     let siteName: string | undefined;
 
-    // if link starts with 'http://' than replace it with 'https://'
-    if (link.startsWith('http://')) {
-      link = link.replace('http://', 'https://');
+    if (!link.match(/^(http|https):\/\//)) {
+      link = `http://${link}`;
     }
 
     await axios

--- a/src/contents/util/content.util.ts
+++ b/src/contents/util/content.util.ts
@@ -10,6 +10,11 @@ export class ContentUtil {
     let description: string | undefined = '';
     let siteName: string | undefined;
 
+    // if link starts with 'http://' than replace it with 'https://'
+    if (link.startsWith('http://')) {
+      link = link.replace('http://', 'https://');
+    }
+
     await axios
       .get(link)
       .then((res) => {


### PR DESCRIPTION
사용자가 링크 저장 시 직접 입력하는 경우
"http"를 생략할 수 있으므로 이 경우를 핸들링 해주어야 한다.

Closes #197 