### PR TITLE
Feature/#203 카테고리 자동 지정 테스트를 위한 api 추가 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "crypto-js": "^4.1.1",
         "form-data": "^4.0.0",
         "joi": "^17.6.0",
+        "openai": "^3.3.0",
         "passport": "^0.6.0",
         "passport-google-oauth20": "^2.0.0",
         "passport-jwt": "^4.0.0",
@@ -7372,6 +7373,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openai": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-3.3.0.tgz",
+      "integrity": "sha512-uqxI/Au+aPRnsaQRe8CojU0eCR7I0mBiKjD3sNMzY6DaC1ZVrc85u98mtJW6voDug8fgGN+DIZmTDxTthxb7dQ==",
+      "dependencies": {
+        "axios": "^0.26.0",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/openai/node_modules/axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "dependencies": {
+        "follow-redirects": "^1.14.8"
       }
     },
     "node_modules/optionator": {
@@ -15656,6 +15674,25 @@
       "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
+      }
+    },
+    "openai": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-3.3.0.tgz",
+      "integrity": "sha512-uqxI/Au+aPRnsaQRe8CojU0eCR7I0mBiKjD3sNMzY6DaC1ZVrc85u98mtJW6voDug8fgGN+DIZmTDxTthxb7dQ==",
+      "requires": {
+        "axios": "^0.26.0",
+        "form-data": "^4.0.0"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.26.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+          "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+          "requires": {
+            "follow-redirects": "^1.14.8"
+          }
+        }
       }
     },
     "optionator": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "crypto-js": "^4.1.1",
     "form-data": "^4.0.0",
     "joi": "^17.6.0",
+    "openai": "^3.3.0",
     "passport": "^0.6.0",
     "passport-google-oauth20": "^2.0.0",
     "passport-jwt": "^4.0.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -12,6 +12,7 @@ import { CollectionsModule } from './collections/collections.module';
 import { BatchModule } from './batch/batch.module';
 import { SummaryModule } from './summary/summary.module';
 import { TypeOrmConfigService } from './database/typerom-config.service';
+import { OpenaiModule } from './openai/openai.module';
 
 @Module({
   imports: [
@@ -98,6 +99,7 @@ import { TypeOrmConfigService } from './database/typerom-config.service';
         ? process.env.NAVER_CLOVA_SUMMARY_REQUEST_URL
         : '',
     }),
+    OpenaiModule,
   ],
   controllers: [],
   providers: [],

--- a/src/openai/dto/create-completion.dto.ts
+++ b/src/openai/dto/create-completion.dto.ts
@@ -1,0 +1,5 @@
+export class CreateCompletionBodyDto {
+  question!: string;
+  model?: string;
+  temperature?: number;
+}

--- a/src/openai/openai.controller.ts
+++ b/src/openai/openai.controller.ts
@@ -1,0 +1,16 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { OpenaiService } from './openai.service';
+import { CreateCompletionBodyDto } from './dto/create-completion.dto';
+import { CreateChatCompletionResponse } from 'openai';
+
+@Controller('openai')
+export class OpenaiController {
+  constructor(private readonly openaiService: OpenaiService) {}
+
+  @Post('/chat-completion')
+  async createChatCompletion(
+    @Body() createCompletionBodyDto: CreateCompletionBodyDto,
+  ): Promise<CreateChatCompletionResponse> {
+    return this.openaiService.createChatCompletion(createCompletionBodyDto);
+  }
+}

--- a/src/openai/openai.module.ts
+++ b/src/openai/openai.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { OpenaiController } from './openai.controller';
+import { OpenaiService } from './openai.service';
+
+@Module({
+  controllers: [OpenaiController],
+  providers: [OpenaiService]
+})
+export class OpenaiModule {}

--- a/src/openai/openai.service.spec.ts
+++ b/src/openai/openai.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { OpenaiService } from './openai.service';
+
+describe('OpenaiService', () => {
+  let service: OpenaiService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [OpenaiService],
+    }).compile();
+
+    service = module.get<OpenaiService>(OpenaiService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/openai/openai.service.ts
+++ b/src/openai/openai.service.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Configuration, CreateChatCompletionResponse, OpenAIApi } from 'openai';
+import { CreateCompletionBodyDto } from './dto/create-completion.dto';
+
+@Injectable()
+export class OpenaiService {
+  private readonly openAIApi: OpenAIApi;
+  constructor(private readonly configService: ConfigService) {
+    this.openAIApi = new OpenAIApi(
+      new Configuration({
+        organization: this.configService.get('OPENAI_ORGANIZATION_ID'),
+        apiKey: this.configService.get('OPENAI_API_KEY'),
+      }),
+    );
+  }
+
+  async createChatCompletion({
+    question,
+    model,
+    temperature,
+  }: CreateCompletionBodyDto): Promise<CreateChatCompletionResponse> {
+    try {
+      const { data } = await this.openAIApi.createChatCompletion({
+        model: model || 'gpt-3.5-turbo',
+        messages: [
+          {
+            role: 'user',
+            content: question,
+          },
+        ],
+        temperature: temperature || 0.9,
+      });
+
+      return data;
+    } catch (e) {
+      throw e;
+    }
+  }
+}


### PR DESCRIPTION
요청사항에 따라
url 삽입 시, 직접 설정한 카테고리 중 어느 카테고리가 지정될 지 확인 가능하도록
테스트용 api를 구현하려했으나

gpt-3.5-turbo-0613 모델의 경우 , 질문에 url이 포함되어있으면
"Based on the URL provided, it is not possible to determine the category of the link."와 같은 문구를 반환함.

gpt에게 url을 넘겨서 원하는 결과를 받기는 어려울 것으로 판단, 구현 전까지는 직접 정보를 프롬프트에 담아보내야할 것으로 보임.

Closes #203 