### PR TITLE
Hotfix/#211 최상단 카테고리 삭제 시 발생하는 이슈 해결

### DIFF
--- a/src/contents/entities/category.entity.ts
+++ b/src/contents/entities/category.entity.ts
@@ -26,8 +26,8 @@ export class Category extends CoreEntity {
   collections!: Collection[];
 
   @ApiProperty({ description: 'Category Parent ID' })
-  @Column({ nullable: true })
-  parentId?: number;
+  @Column({ type: 'int', nullable: true })
+  parentId?: number | null;
 
   @ManyToOne((type) => User, (user) => user.categories, {
     onDelete: 'CASCADE',

--- a/src/contents/repository/category.repository.ts
+++ b/src/contents/repository/category.repository.ts
@@ -48,7 +48,9 @@ export class CategoryRepository extends Repository<Category> {
         if (i === 1 && parentCategory?.parentId !== null) {
           throw new ConflictException('Category depth should be 3');
         }
-        currentParentId = parentCategory?.parentId;
+        if (parentCategory?.parentId)
+          currentParentId = parentCategory?.parentId;
+        else break;
       }
     }
     // check if category exists in user's categories


### PR DESCRIPTION
## 이슈 내용
2단을 삭제하면 3단이었던 카테고리는 1단인 카테고리를 부모 카테고리로 변경하는 것은 동작하는데
1단을 삭제하는 경우 2단이었던 카테고리가 1단으로, 즉 부모가 없도록 변경되어야하는데 그렇지 않고 삭제된 카테고리를 여전히 부모로 저장하고 있음

## 원인
부모 카테고리가 없는 1단 카테고리가 삭제되는 경우 하위 카테고리에게 undefined를 할당하여 부모 정보를 업데이트했는데, 이게 db에 반영되지 않아 null을 할당해야했음.
  
<br/> 
 
[how-to-set-a-nullable-database-field-to-null-with-typeorm](https://stackoverflow.com/questions/64635617/how-to-set-a-nullable-database-field-to-null-with-typeorm)

위 내용을 참고하여 문제 해결