### PR TITLE
Feature/#214 소셜 프로필 이미지 처리

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -273,7 +273,8 @@ export class OauthService {
 
       const { user, exist } = await this.userRepository.getOrCreateAccount({
         email,
-        name: userInfo.properties.nickname,
+        name: userInfo.kakao_account.profile.nickname,
+        profileImage: userInfo.kakao_account.profile?.profile_image_url,
         password: CryptoJS.SHA256(email + process.env.KAKAO_JS_KEY).toString(),
       });
 
@@ -289,11 +290,16 @@ export class OauthService {
   }
 
   // Login with Google account info
-  async googleOauth({ email, name }: googleUserInfo): Promise<LoginOutput> {
+  async googleOauth({
+    email,
+    name,
+    picture,
+  }: googleUserInfo): Promise<LoginOutput> {
     try {
       const { user, exist } = await this.userRepository.getOrCreateAccount({
         email,
         name,
+        profileImage: picture,
         password: CryptoJS.SHA256(
           email + process.env.GOOGLE_CLIENT_ID,
         ).toString(),

--- a/src/auth/dtos/google.dto.ts
+++ b/src/auth/dtos/google.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEmail, IsString } from 'class-validator';
+import { IsEmail, IsOptional, IsString } from 'class-validator';
 
 export class googleUserInfo {
   @ApiProperty({ description: 'google user email' })
@@ -9,6 +9,11 @@ export class googleUserInfo {
   @ApiProperty({ description: 'google user name' })
   @IsString()
   name!: string;
+
+  @ApiProperty({ description: 'google user profile image' })
+  @IsString()
+  @IsOptional()
+  picture?: string;
 
   @ApiProperty({ description: 'google user access token' })
   @IsString()

--- a/src/auth/passport/google/google.strategy.ts
+++ b/src/auth/passport/google/google.strategy.ts
@@ -20,13 +20,14 @@ export class GoogleStrategy extends PassportStrategy(Strategy) {
     profile: any,
     done: VerifyCallback,
   ): Promise<any> {
-    const { name, emails /*photos*/ } = profile;
+    console.log(profile);
+    const { name, emails, photos } = profile;
     const user = {
       email: emails[0].value,
       name: name.familyName + name.givenName,
       // firstName: name.givenName,
       // lastName: name.familyName,
-      // picture: photos[0].value,
+      picture: photos[0].value,
       accessToken,
     };
     done(null, user);

--- a/src/database/migrations/1699435419691-userprofileimage.ts
+++ b/src/database/migrations/1699435419691-userprofileimage.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class userprofileimage1699435419691 implements MigrationInterface {
+    name = 'userprofileimage1699435419691'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "user" ADD "profileImage" character varying`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "user" DROP COLUMN "profileImage"`);
+    }
+
+}

--- a/src/users/dtos/get-or-create-account.dto.ts
+++ b/src/users/dtos/get-or-create-account.dto.ts
@@ -4,5 +4,6 @@ import { User } from '../entities/user.entity';
 export class GetOrCreateAccountBodyDto extends PickType(User, [
   'email',
   'name',
+  'profileImage',
   'password',
 ]) {}

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -33,6 +33,11 @@ export class User extends CoreEntity {
   @IsEmail()
   email!: string;
 
+  @ApiProperty({ example: 'https://ex.com', description: 'User Profile Image' })
+  @Column({ nullable: true })
+  @IsString()
+  profileImage?: string;
+
   @ApiProperty({ example: 'passw0rd', description: 'User Password' })
   @Column({ select: false })
   @IsString()

--- a/src/users/repository/user.repository.ts
+++ b/src/users/repository/user.repository.ts
@@ -49,7 +49,7 @@ export class UserRepository extends Repository<User> {
     userInfo: GetOrCreateAccountBodyDto,
   ): Promise<{ user: User; exist: number }> {
     try {
-      const { email, name, password } = userInfo;
+      const { email, name, profileImage, password } = userInfo;
       let user = await this.findOneBy({
         email,
       });
@@ -60,6 +60,7 @@ export class UserRepository extends Repository<User> {
           this.create({
             email,
             name,
+            profileImage,
             password,
             verified: true,
           }),


### PR DESCRIPTION
OAuth 회원가입 시 프로필 사진도 받아오도록 작업.

카카오 동의항목에 선택적으로 프로필 사진 제공에 동의하도록 추가해둠.

[kakao profile api docs](https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#profile)
[google cloud console](https://console.cloud.google.com/)

Closes #214
