### PR TITLE
Hotfix/#216 닉네임만 body에 실어보내는 경우 처리

### DIFF
--- a/src/common/interceptors/transaction.interceptor.ts
+++ b/src/common/interceptors/transaction.interceptor.ts
@@ -24,14 +24,17 @@ export class TransactionInterceptor implements NestInterceptor {
 
     return next.handle().pipe(
       catchError(async (e) => {
-        console.log('check err ', e.message);
         await queryRunner.rollbackTransaction();
         await queryRunner.release();
 
+        const errorMessage = e.response.message[0]
+          ? e.response.message[0]
+          : e.message;
+
         if (e instanceof HttpException) {
-          throw new HttpException(e.message, e.getStatus());
+          throw new HttpException(errorMessage, e.getStatus());
         } else {
-          throw new InternalServerErrorException(e.message);
+          throw new InternalServerErrorException(errorMessage);
         }
       }),
       tap(async () => {

--- a/src/users/dtos/edit-profile.dto.ts
+++ b/src/users/dtos/edit-profile.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty, PartialType, PickType } from '@nestjs/swagger';
-import { IsString } from 'class-validator';
+import { IsOptional, IsString } from 'class-validator';
 import { CoreOutput } from '../../common/dtos/output.dto';
 import { User } from '../entities/user.entity';
 
@@ -10,5 +10,6 @@ export class EditProfileInput extends PartialType(
 ) {
   @ApiProperty({ description: '기존 비밀번호', required: false })
   @IsString()
+  @IsOptional()
   oldPassword?: string;
 }

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -40,7 +40,7 @@ export class User extends CoreEntity {
 
   @ApiProperty({ example: 'passw0rd', description: 'User Password' })
   @Column({ select: false })
-  @IsString()
+  @IsString({ message: 'Password is required' })
   @Matches(/^(?=.*\d)[A-Za-z\d@$!%*?&]{8,}$/, {
     message: 'Password must be at least 8 characters long, contain 1 number',
   })


### PR DESCRIPTION
닉네임만 body에 실어보내는 경우 400 error가 발생함.
[닉네임 변경 이슈](https://github.com/Quickchive/quick-archive-frontend/issues/50)

oldPassword 항목이 Optional 처리되어있지 않아 발생하던 문제였으며, Optional 처리함.

Closes #216 