### PR TITLE
feat: prompt를 개선하여 None을 보다 적절하게 뱉도록 개선- #209

### DIFF
--- a/src/contents/contents.service.ts
+++ b/src/contents/contents.service.ts
@@ -878,6 +878,7 @@ export class CategoryService {
 
       // Join all lines together into a single string
       const question = questionLines.join(' ');
+      console.log(question);
 
       const response = await this.openaiService.createChatCompletion({
         question,
@@ -905,17 +906,19 @@ export class CategoryService {
       const content = await this.contentUtil.getLinkContent(link);
 
       let questionLines = [
-        "You are now auto categorizing machine. You can only answer a single category name or None. Here is the article's information:",
+        "You are a machine tasked with auto-categorizing articles based on information obtained through web scraping. You can only answer a single category name. Here is the article's information:",
       ];
 
       if (title) {
-        questionLines.push(`The title is "${title.trim()}"`);
+        questionLines.push(
+          `The article in question is titled "${title.trim()}"`,
+        );
       }
 
       if (content) {
         const contentLength = content.length / 2;
         questionLines.push(
-          `The opening 150 characters of the article read, "${content
+          `The 150 characters of the article is, "${content
             .replace(/\s/g, '')
             .slice(contentLength - 150, contentLength + 150)
             .trim()}"`,
@@ -932,9 +935,9 @@ export class CategoryService {
 
       // Add the category options to the end of the list
       questionLines.push(
-        `Please tell me the most appropriate category among the following. If none are suitable, return None. Here is Category options: [${categories.join(
+        `Please provide the most suitable category among the following. Here is Category options: [${categories.join(
           ', ',
-        )}]`,
+        )}, None]`,
       );
 
       // Join all lines together into a single string

--- a/src/openai/openai.service.ts
+++ b/src/openai/openai.service.ts
@@ -29,7 +29,7 @@ export class OpenaiService {
             content: question,
           },
         ],
-        temperature: temperature || 0.9,
+        temperature: temperature || 0.1,
       });
 
       return data;


### PR DESCRIPTION
gpt 페이지에서 확인한 결과와 api를 사용하여 확인한 결과가 다른 이슈를 프롬프트를 개선하여 해결


### Old version
```
You are now auto categorizing machine. You can only answer a single category name or None. Here is the article's information: The title is "[GRL Book 정리] Chapter 4. Multi-relational Data and Knowledge Graphs - 재야의 숨은 초보" The opening 150 characters of the article read, "가0또는1값만갖기때문에제곱오차$\lVert\cdot\rVert^2$의선택이적절하지않다는점이다.분류문제로접근하여크로스엔트로피손실함수를사용하는것이더적절할것이다.식$(4.2)$의문제점을해결할수있는한가지손실함수는네거티브샘플링을이용한크로스엔트로피손실함수이다.네거티브샘플링을이용한크로스엔트로피손실함수는다음과같다.\[\mathcal{L}=\sum\limits_{(u,\tau,v)\in\mathcal{E}}-\log(\sigma(\text{DEC}(\mathbf{z}_u,\tau,\mathbf{z}_v)))-\gamma\mathbb{E}_{v_n\" The description is 재야의 숨은 고수가 되고 싶은 초심자" The site's name is "재야의 숨은 초보" Please tell me the most appropriate category among the following. If none are suitable, return None. Here is Category options: [게임, 개발, 인공지능, 쇼핑, 시계열알고리즘, 꿀팁, 일상, 음악, 대학원, 취업, 읽을 것들]
```

### New version
```
You are a machine tasked with auto-categorizing articles based on information obtained through web scraping. You can only answer a single category name. Here is the article's information: The article in question is titled "[GRL Book 정리] Chapter 4. Multi-relational Data and Knowledge Graphs - 재야의 숨은 초보" The 150 characters of the article is, "가0또는1값만갖기때문에제곱오차$\lVert\cdot\rVert^2$의선택이적절하지않다는점이다.분류문제로접근하여크로스엔트로피손실함수를사용하는것이더적절할것이다.식$(4.2)$의문제점을해결할수있는한가지손실함수는네거티브샘플링을이용한크로스엔트로피손실함수이다.네거티브샘플링을이용한크로스엔트로피손실함수는다음과같다.\[\mathcal{L}=\sum\limits_{(u,\tau,v)\in\mathcal{E}}-\log(\sigma(\text{DEC}(\mathbf{z}_u,\tau,\mathbf{z}_v)))-\gamma\mathbb{E}_{v_n\" The description is 재야의 숨은 고수가 되고 싶은 초심자" The site's name is "재야의 숨은 초보" Please provide the most suitable category among the following. Here is Category options: [게임, 개발, 인공지능, 쇼핑, 시계열알고리즘, 꿀팁, 일상, 음악, 대학원, 취업, 읽을 것들, None]
```


Closes #209 