### PR TITLE
[Feature] Og 데이터 크롤링

### DIFF
--- a/src/contents/contents.controller.ts
+++ b/src/contents/contents.controller.ts
@@ -61,6 +61,7 @@ import {
   LoadPersonalContentsOutput,
 } from './dtos/load-personal-contents.dto';
 import { LoadReminderCountOutput } from './dtos/load-personal-remider-count.dto';
+import { GetLinkInfoResponseDto } from './dtos/get-link.response.dto';
 
 @Controller('contents')
 @ApiTags('Contents')
@@ -254,6 +255,19 @@ export class ContentsController {
     @AuthUser() user: User,
   ): Promise<LoadReminderCountOutput> {
     return this.contentsService.loadReminderCount(user);
+  }
+
+  @ApiOperation({
+    summary: 'OG 데이터 크롤링',
+    description: '링크 내 OG 데이터를 파싱합니다.',
+  })
+  @ApiOkResponse({
+    type: GetLinkInfoResponseDto,
+  })
+  @UseGuards(JwtAuthGuard)
+  @Get('/og')
+  async getOgData(@Query('link') link: string) {
+    return this.contentsService.getLinkInfo(link);
   }
 
   @ApiOperation({

--- a/src/contents/contents.service.ts
+++ b/src/contents/contents.service.ts
@@ -48,6 +48,7 @@ import { CategoryUtil } from './util/category.util';
 import { CategoryRepository } from './repository/category.repository';
 import { ContentUtil } from './util/content.util';
 import { OpenaiService } from '../openai/openai.service';
+import { GetLinkInfoResponseDto } from './dtos/get-link.response.dto';
 
 @Injectable()
 export class ContentsService {
@@ -404,6 +405,12 @@ export class ContentsService {
     } catch (e) {
       throw e;
     }
+  }
+
+  async getLinkInfo(link: string) {
+    const data = await this.contentUtil.getLinkInfo(link);
+
+    return new GetLinkInfoResponseDto(data);
   }
 
   async testSummarizeContent({

--- a/src/contents/dtos/get-link.response.dto.ts
+++ b/src/contents/dtos/get-link.response.dto.ts
@@ -1,0 +1,37 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { LinkInfo } from '../types/link-info.interface';
+
+export class GetLinkInfoResponseDto {
+  @ApiProperty({
+    description: '아티클 제목',
+    example: '[Terraform] 테라폼 훑어보기 — 턴태의 밑바닥부터 시작하는 de-vlog',
+  })
+  private readonly title: string;
+
+  @ApiProperty({
+    description: '아티클 본문 일부',
+    example:
+      '인프라 구조마저 코드로 조작하고 있는 현재, 가장 많이 쓰이는 도구는 테라폼과 앤서블이 있습니다.',
+  })
+  private readonly description: string;
+
+  @ApiProperty({
+    description: '썸네일/커버 이미지',
+    example:
+      'https://img1.daumcdn.net/thumb/R800x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2Fz52vz%2FbtsCAOBzgTR%2FhFgGDKkr6iKWfU6eKeKUVk%2Fimg.png',
+  })
+  private readonly coverImg: string;
+
+  @ApiPropertyOptional({
+    description: '아티클 사이트 주소',
+    example: '턴태의 밑바닥부터 시작하는 de-vlog',
+  })
+  private readonly siteName?: string;
+
+  constructor(linkInfo: LinkInfo) {
+    this.title = linkInfo.title;
+    this.description = linkInfo.description;
+    this.coverImg = linkInfo.coverImg;
+    this.siteName = linkInfo.siteName;
+  }
+}

--- a/src/contents/types/link-info.interface.ts
+++ b/src/contents/types/link-info.interface.ts
@@ -1,0 +1,6 @@
+export interface LinkInfo {
+  title: string;
+  description: string;
+  coverImg: string;
+  siteName?: string;
+}


### PR DESCRIPTION
<img width="1078" alt="image" src="https://github.com/Quickchive/quickchive-backend/assets/83271772/b89cc5a8-3ee3-4f9a-957a-60a310ab1f09">

- Link를 받아 해당 아티클의 og 데이터를 가져옵니다.